### PR TITLE
매크로 덜어내기, calc_all_recent_cpu() 추가

### DIFF
--- a/devices/timer.c
+++ b/devices/timer.c
@@ -174,12 +174,12 @@ timer_interrupt(struct intr_frame *args UNUSED)
     if (timer_ticks() % TIMER_FREQ == 0)
     {
         calc_load_avg();
-        calc_recent_cpu();
+        calc_all_recent_cpu();
     }
-    // if (timer_ticks() % 4 == 0)
-    // {
-    //     calc_priority();
-    // }
+    if (timer_ticks() % 4 == 0)
+    {
+        calc_all_priority();
+    }
 }
 
 /* Returns true if LOOPS iterations waits for more than one timer

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -160,8 +160,8 @@ int thread_get_recent_cpu(void);
 int thread_get_load_avg(void);
 
 void calc_load_avg();
-void calc_recent_cpu();
-int calc_priority();
+void calc_all_recent_cpu();
+void calc_all_priority();
 
 void do_iret(struct intr_frame *tf);
 


### PR DESCRIPTION
로직 수정 전, 커밋 한 번 진행합니다.

매크로 덜어내기
- `calc_load_avg()`에서 사용한 매크로를 적게 사용할 수 있게 수정

`calc_all_recent_cpu()` 추가
- 모든 스레드의 `recent_cpu`를 수정하는 함수를 추가
- timer.c `time_interrupt()`에 `calc_recent_cpu()`를 대체하여 추가
- thread.h에 `calc_recent_cpu()`를 대체하여 추가
- thread.c에 새로 생성