### PR TITLE
Mlfqs TEST ALL PASS

### DIFF
--- a/devices/timer.c
+++ b/devices/timer.c
@@ -173,13 +173,13 @@ timer_interrupt(struct intr_frame *args UNUSED)
 
     if (!thread_mlfqs)
         return;
-    if (timer_ticks() % TIMER_FREQ == 0)
-    {
-        calc_load_avg();
-        // calc_all_recent_cpu();
-    }
     if (timer_ticks() % 4 == 0)
     {
+        if (timer_ticks() % TIMER_FREQ == 0)
+        {
+            calc_load_avg();
+            calc_all_recent_cpu();
+        }
         calc_all_priority();
     }
 }


### PR DESCRIPTION
mlfqs-load-60
- priority 계산식에서 `recent_cpu` 값을 고정 소수점 -> 일반 정수로 변환 후 계산하도록 변경. 
해당 과정에서 매크로 `TOINT_ZERO`를 추가.
- `priority` MAX, MIN 한계를 고정하지 않았었기 때문에 priority가 200, 300을 넘어서는 상태였음. 한계값을 넘지 못하도록 조정. 

mlfqs-load-avg, mlfqs-recent-1
- `thread_list`에 main 스레드가 포함되지 않는 상태였음. main 스레드를 포함할 수 있도록 
`list_push_back(&thread_list, t->th_elem)`의 호출 위치를 `thread_create()`에서 `init_thread()`로 변경하였음.
- `thread_set_nice()`에서 `thread_yield()`를 호출하지 않게 변경. 
/ 했었으나 `thread_yield()`를 호출해도 테스트는 통과가 됨. 동작에 영향을 주지 않는 것으로 확인되었음.

이 후, mlfqs-block, mlfqs-nice-2, mlfqs-nice-20, mlfqs-fair-2, mlfqs-fair-20 모두 통과하였음.