### PR TITLE
Mlfqs 최종 Merge

### DIFF
--- a/devices/timer.c
+++ b/devices/timer.c
@@ -174,7 +174,7 @@ timer_interrupt(struct intr_frame *args UNUSED)
     if (timer_ticks() % TIMER_FREQ == 0)
     {
         calc_load_avg();
-        // calc_recent_cpu();
+        calc_recent_cpu();
     }
     // if (timer_ticks() % 4 == 0)
     // {

--- a/devices/timer.c
+++ b/devices/timer.c
@@ -88,7 +88,7 @@ void timer_calibrate(void)
 }
 
 /* Returns the number of timer ticks since the OS booted.
-   OS가 부팅된 이후의 타이머 틱 수를 반환합니다.
+    OS가 부팅된 이후의 타이머 틱 수를 반환합니다.
 */
 int64_t
 timer_ticks(void)
@@ -102,7 +102,7 @@ timer_ticks(void)
 
 /* Returns the number of timer ticks elapsed since THEN, which
    should be a value once returned by timer_ticks().
-   THEN 이후에 경과한 타이머 틱 수를 반환합니다. 이 값은 timer_ticks()로 반환된 값이어야 합니다.
+    THEN 이후에 경과한 타이머 틱 수를 반환합니다. 이 값은 timer_ticks()로 반환된 값이어야 합니다.
 */
 int64_t
 timer_elapsed(int64_t then)
@@ -134,35 +134,35 @@ void timer_sleep(int64_t ticks)
 }
 
 /* Suspends execution for approximately MS milliseconds.
-   대략적으로 MS 밀리초 동안 실행을 중단합니다. */
+    대략적으로 MS 밀리초 동안 실행을 중단합니다. */
 void timer_msleep(int64_t ms)
 {
     real_time_sleep(ms, 1000);
 }
 
 /* Suspends execution for approximately US microseconds.
-   대략적으로 US 마이크로초 동안 실행을 중단합니다. */
+    대략적으로 US 마이크로초 동안 실행을 중단합니다. */
 void timer_usleep(int64_t us)
 {
     real_time_sleep(us, 1000 * 1000);
 }
 
 /* Suspends execution for approximately NS nanoseconds.
-   대략적으로 NS 나노초 동안 실행을 중단합니다. */
+    대략적으로 NS 나노초 동안 실행을 중단합니다. */
 void timer_nsleep(int64_t ns)
 {
     real_time_sleep(ns, 1000 * 1000 * 1000);
 }
 
 /* Prints timer statistics.
-   타이머 통계를 출력합니다. */
+    타이머 통계를 출력합니다. */
 void timer_print_stats(void)
 {
     printf("Timer: %" PRId64 " ticks\n", timer_ticks());
 }
 
 /* Timer interrupt handler.
-   타이머 인터럽트 핸들러입니다. */
+    타이머 인터럽트 핸들러입니다. */
 static void
 timer_interrupt(struct intr_frame *args UNUSED)
 {
@@ -170,17 +170,6 @@ timer_interrupt(struct intr_frame *args UNUSED)
     thread_tick();
 
     thread_wakeup(ticks);
-
-    // 1초마다 재계산   1초에 100틱 = TIMER_FREQ
-    if (timer_ticks() % TIMER_FREQ == 0)
-    {
-        calc_load_avg();
-        calc_recent_cpu();
-    }
-
-    // 4틱마다 재계산
-    if (timer_ticks() % 4 == 0)
-        calc_priority();
 }
 
 /* Returns true if LOOPS iterations waits for more than one timer
@@ -222,7 +211,7 @@ busy_wait(int64_t loops)
 {
     while (loops-- > 0) // loops가 0인지 측정하고 라인나갈때 loops를 하나뺀다.
         barrier();      // barrier는 아무것도 안하므로, 계속 빼다가 loops가 0이되면 탈출한다.
-                        // 이것은 단지 딜레이의 구현을 위해 쓰여졌다?
+    // 이것은 단지 딜레이의 구현을 위해 쓰여졌다?
 }
 
 /* Sleep for approximately NUM/DENOM seconds.

--- a/devices/timer.c
+++ b/devices/timer.c
@@ -167,7 +167,6 @@ static void
 timer_interrupt(struct intr_frame *args UNUSED)
 {
     ticks++;
-    thread_tick();
 
     thread_wakeup(ticks);
 
@@ -180,6 +179,8 @@ timer_interrupt(struct intr_frame *args UNUSED)
     {
         calc_all_priority();
     }
+
+    thread_tick();
 }
 
 /* Returns true if LOOPS iterations waits for more than one timer

--- a/devices/timer.c
+++ b/devices/timer.c
@@ -168,19 +168,20 @@ timer_interrupt(struct intr_frame *args UNUSED)
 {
     ticks++;
 
+    thread_tick();
     thread_wakeup(ticks);
 
+    if (!thread_mlfqs)
+        return;
     if (timer_ticks() % TIMER_FREQ == 0)
     {
         calc_load_avg();
-        calc_all_recent_cpu();
+        // calc_all_recent_cpu();
     }
     if (timer_ticks() % 4 == 0)
     {
         calc_all_priority();
     }
-
-    thread_tick();
 }
 
 /* Returns true if LOOPS iterations waits for more than one timer

--- a/devices/timer.c
+++ b/devices/timer.c
@@ -174,12 +174,12 @@ timer_interrupt(struct intr_frame *args UNUSED)
     if (timer_ticks() % TIMER_FREQ == 0)
     {
         calc_load_avg();
-        calc_recent_cpu();
+        calc_all_recent_cpu();
     }
-    // if (timer_ticks() % 4 == 0)
-    // {
-    //     calc_priority();
-    // }
+    if (timer_ticks() % 4 == 0)
+    {
+        calc_all_priority();
+    }
 }
 
 /* Returns true if LOOPS iterations waits for more than one timer

--- a/devices/timer.c
+++ b/devices/timer.c
@@ -41,18 +41,18 @@ static void real_time_sleep(int64_t num, int32_t denom);
 
 void timer_init(void)
 {
-   /* 8254 input frequency divided by TIMER_FREQ, rounded to
-      nearest.
+    /* 8254 input frequency divided by TIMER_FREQ, rounded to
+       nearest.
 
-      8254 입력 빈도를 TIMER_FREQ로 나눈 값으로 가장 가까운 값으로 반올림합니다.
-      */
-   uint16_t count = (1193180 + TIMER_FREQ / 2) / TIMER_FREQ;
+       8254 입력 빈도를 TIMER_FREQ로 나눈 값으로 가장 가까운 값으로 반올림합니다.
+       */
+    uint16_t count = (1193180 + TIMER_FREQ / 2) / TIMER_FREQ;
 
-   outb(0x43, 0x34); /* CW: counter 0, LSB then MSB, mode 2, binary. */
-   outb(0x40, count & 0xff);
-   outb(0x40, count >> 8);
+    outb(0x43, 0x34); /* CW: counter 0, LSB then MSB, mode 2, binary. */
+    outb(0x40, count & 0xff);
+    outb(0x40, count >> 8);
 
-   intr_register_ext(0x20, timer_interrupt, "8254 Timer");
+    intr_register_ext(0x20, timer_interrupt, "8254 Timer");
 }
 
 /* Calibrates loops_per_tick, used to implement brief delays.
@@ -60,31 +60,31 @@ void timer_init(void)
 
 void timer_calibrate(void)
 {
-   unsigned high_bit, test_bit;
+    unsigned high_bit, test_bit;
 
-   ASSERT(intr_get_level() == INTR_ON);
-   printf("Calibrating timer...  ");
+    ASSERT(intr_get_level() == INTR_ON);
+    printf("Calibrating timer...  ");
 
-   /* Approximate loops_per_tick as the largest power-of-two
-      still less than one timer tick.
-      loops_per_tick을 타이머 틱보다 작은 가장 큰 2의 거듭제곱으로 대략적으로 설정합니다.
-      */
-   loops_per_tick = 1u << 10;
-   while (!too_many_loops(loops_per_tick << 1))
-   {
-      loops_per_tick <<= 1;
-      ASSERT(loops_per_tick != 0);
-   }
+    /* Approximate loops_per_tick as the largest power-of-two
+       still less than one timer tick.
+       loops_per_tick을 타이머 틱보다 작은 가장 큰 2의 거듭제곱으로 대략적으로 설정합니다.
+       */
+    loops_per_tick = 1u << 10;
+    while (!too_many_loops(loops_per_tick << 1))
+    {
+        loops_per_tick <<= 1;
+        ASSERT(loops_per_tick != 0);
+    }
 
-   /* Refine the next 8 bits of loops_per_tick.
-      loops_per_tick의 다음 8비트를 보정합니다.
-   */
-   high_bit = loops_per_tick;
-   for (test_bit = high_bit >> 1; test_bit != high_bit >> 10; test_bit >>= 1)
-      if (!too_many_loops(high_bit | test_bit))
-         loops_per_tick |= test_bit;
+    /* Refine the next 8 bits of loops_per_tick.
+       loops_per_tick의 다음 8비트를 보정합니다.
+    */
+    high_bit = loops_per_tick;
+    for (test_bit = high_bit >> 1; test_bit != high_bit >> 10; test_bit >>= 1)
+        if (!too_many_loops(high_bit | test_bit))
+            loops_per_tick |= test_bit;
 
-   printf("%'" PRIu64 " loops/s.\n", (uint64_t)loops_per_tick * TIMER_FREQ);
+    printf("%'" PRIu64 " loops/s.\n", (uint64_t)loops_per_tick * TIMER_FREQ);
 }
 
 /* Returns the number of timer ticks since the OS booted.
@@ -93,11 +93,11 @@ void timer_calibrate(void)
 int64_t
 timer_ticks(void)
 {
-   enum intr_level old_level = intr_disable(); // '이전 인터럽트 상태'를 인터럽트 불가로 설정?
-   int64_t t = ticks;                          // OS가 부팅된 이후 타이머의 틱 수를 t에 저장
-   intr_set_level(old_level);                  // 현재 인터럽트 레벨을 이전 인터럽트 상태로 설정
-   barrier();
-   return t;
+    enum intr_level old_level = intr_disable(); // '이전 인터럽트 상태'를 인터럽트 불가로 설정?
+    int64_t t = ticks;                          // OS가 부팅된 이후 타이머의 틱 수를 t에 저장
+    intr_set_level(old_level);                  // 현재 인터럽트 레벨을 이전 인터럽트 상태로 설정
+    barrier();
+    return t;
 } // 시간을 반환
 
 /* Returns the number of timer ticks elapsed since THEN, which
@@ -107,7 +107,7 @@ timer_ticks(void)
 int64_t
 timer_elapsed(int64_t then)
 {
-   return timer_ticks() - then;
+    return timer_ticks() - then;
 }
 
 /* Suspends execution for approximately TICKS timer ticks. */
@@ -124,41 +124,41 @@ timer_elapsed(int64_t then)
 /* 쓰레드를 sleep_list에 넣는 함수 */
 void timer_sleep(int64_t ticks)
 {
-   int64_t start = timer_ticks();
+    int64_t start = timer_ticks();
 
-   if (timer_elapsed(start) < ticks)
-   {
-      ASSERT(intr_get_level() == INTR_ON); // 인터럽트가 켜져 있어야 합니다.
-      thread_sleep(start + ticks);         // 현재까지의 OS 시간 + 재우고 싶은 시간
-   }
+    if (timer_elapsed(start) < ticks)
+    {
+        ASSERT(intr_get_level() == INTR_ON); // 인터럽트가 켜져 있어야 합니다.
+        thread_sleep(start + ticks);         // 현재까지의 OS 시간 + 재우고 싶은 시간
+    }
 }
 
 /* Suspends execution for approximately MS milliseconds.
    대략적으로 MS 밀리초 동안 실행을 중단합니다. */
 void timer_msleep(int64_t ms)
 {
-   real_time_sleep(ms, 1000);
+    real_time_sleep(ms, 1000);
 }
 
 /* Suspends execution for approximately US microseconds.
    대략적으로 US 마이크로초 동안 실행을 중단합니다. */
 void timer_usleep(int64_t us)
 {
-   real_time_sleep(us, 1000 * 1000);
+    real_time_sleep(us, 1000 * 1000);
 }
 
 /* Suspends execution for approximately NS nanoseconds.
    대략적으로 NS 나노초 동안 실행을 중단합니다. */
 void timer_nsleep(int64_t ns)
 {
-   real_time_sleep(ns, 1000 * 1000 * 1000);
+    real_time_sleep(ns, 1000 * 1000 * 1000);
 }
 
 /* Prints timer statistics.
    타이머 통계를 출력합니다. */
 void timer_print_stats(void)
 {
-   printf("Timer: %" PRId64 " ticks\n", timer_ticks());
+    printf("Timer: %" PRId64 " ticks\n", timer_ticks());
 }
 
 /* Timer interrupt handler.
@@ -166,21 +166,21 @@ void timer_print_stats(void)
 static void
 timer_interrupt(struct intr_frame *args UNUSED)
 {
-   ticks++;
-   thread_tick();
+    ticks++;
+    thread_tick();
 
-   thread_wakeup(ticks);
+    thread_wakeup(ticks);
 
-   // 1초마다 재계산   1초에 100틱 = TIMER_FREQ
-   if (timer_ticks() % TIMER_FREQ == 0)
-   {
-      calc_load_avg();
-      calc_recent_cpu();
-   }
+    // 1초마다 재계산   1초에 100틱 = TIMER_FREQ
+    if (timer_ticks() % TIMER_FREQ == 0)
+    {
+        calc_load_avg();
+        calc_recent_cpu();
+    }
 
-   // 4틱마다 재계산
-   if (timer_ticks() % 4 == 0)
-      calc_priority();
+    // 4틱마다 재계산
+    if (timer_ticks() % 4 == 0)
+        calc_priority();
 }
 
 /* Returns true if LOOPS iterations waits for more than one timer
@@ -190,21 +190,21 @@ timer_interrupt(struct intr_frame *args UNUSED)
 static bool
 too_many_loops(unsigned loops)
 {
-   /* Wait for a timer tick. */
-   int64_t start = ticks; // 현 sys 시간의 틱누계값을 start로 삼고,
-   while (ticks == start) // while과 바로윗줄의 명령이 순식간에 실행되어서, ticks값이
-                          // 차이가 없다면 아무것도 안하긴 하는데 일단 작동하게 해라. 쨋든 ticks가 증가하면
-                          // while문 탈출
-      barrier();
+    /* Wait for a timer tick. */
+    int64_t start = ticks; // 현 sys 시간의 틱누계값을 start로 삼고,
+    while (ticks == start) // while과 바로윗줄의 명령이 순식간에 실행되어서, ticks값이
+                           // 차이가 없다면 아무것도 안하긴 하는데 일단 작동하게 해라. 쨋든 ticks가 증가하면
+                           // while문 탈출
+        barrier();
 
-   /* Run LOOPS loops.
-       특정 루프를(loops) 반복(LOOPS) 한다. */
-   start = ticks;    // ticks를 다시 start로 삼고
-   busy_wait(loops); //  loops를 인자로 busy_wait를 해라?
+    /* Run LOOPS loops.
+        특정 루프를(loops) 반복(LOOPS) 한다. */
+    start = ticks;    // ticks를 다시 start로 삼고
+    busy_wait(loops); //  loops를 인자로 busy_wait를 해라?
 
-   /* If the tick count changed, we iterated too long. */
-   barrier();
-   return start != ticks;
+    /* If the tick count changed, we iterated too long. */
+    barrier();
+    return start != ticks;
 }
 
 /* Iterates through a simple loop LOOPS times, for implementing
@@ -220,9 +220,9 @@ too_many_loops(unsigned loops)
 static void NO_INLINE
 busy_wait(int64_t loops)
 {
-   while (loops-- > 0) // loops가 0인지 측정하고 라인나갈때 loops를 하나뺀다.
-      barrier();       // barrier는 아무것도 안하므로, 계속 빼다가 loops가 0이되면 탈출한다.
-                       // 이것은 단지 딜레이의 구현을 위해 쓰여졌다?
+    while (loops-- > 0) // loops가 0인지 측정하고 라인나갈때 loops를 하나뺀다.
+        barrier();      // barrier는 아무것도 안하므로, 계속 빼다가 loops가 0이되면 탈출한다.
+                        // 이것은 단지 딜레이의 구현을 위해 쓰여졌다?
 }
 
 /* Sleep for approximately NUM/DENOM seconds.
@@ -230,32 +230,32 @@ busy_wait(int64_t loops)
 static void
 real_time_sleep(int64_t num, int32_t denom)
 {
-   /* Convert NUM/DENOM seconds into timer ticks, rounding down.
-       버림하여, 숫자/분모 초를 타이머의 틱 단위로 바꾼다.
+    /* Convert NUM/DENOM seconds into timer ticks, rounding down.
+        버림하여, 숫자/분모 초를 타이머의 틱 단위로 바꾼다.
 
-      (NUM / DENOM) s
-      ---------------------- = NUM * TIMER_FREQ / DENOM ticks.
-      1 s / TIMER_FREQ(타이머가 초당 인터럽트 하는 횟수) ticks
+       (NUM / DENOM) s
+       ---------------------- = NUM * TIMER_FREQ / DENOM ticks.
+       1 s / TIMER_FREQ(타이머가 초당 인터럽트 하는 횟수) ticks
 
-      */
-   int64_t ticks = num * TIMER_FREQ / denom;
-   // ticks를 할당한다.
+       */
+    int64_t ticks = num * TIMER_FREQ / denom;
+    // ticks를 할당한다.
 
-   ASSERT(intr_get_level() == INTR_ON); //  인터럽트가 켜져야 진행된다.
-   if (ticks > 0)
-   {
-      /* We're waiting for at least one full timer tick.  Use
-         timer_sleep() because it will yield the CPU to other
-         processes.
-         timer_sleep()을 써라. 그래야 CPU를 다른 프로세스들에게 양보한다. */
-      timer_sleep(ticks);
-   }
-   else
-   {
-      /* Otherwise, use a busy-wait loop for more accurate
-         sub-tick tim to ing.  We scale the numerator and denominator
-         down by 1000avoid the possibility of overflow. */
-      ASSERT(denom % 1000 == 0);
-      busy_wait(loops_per_tick * num / 1000 * TIMER_FREQ / (denom / 1000));
-   }
+    ASSERT(intr_get_level() == INTR_ON); //  인터럽트가 켜져야 진행된다.
+    if (ticks > 0)
+    {
+        /* We're waiting for at least one full timer tick.  Use
+           timer_sleep() because it will yield the CPU to other
+           processes.
+           timer_sleep()을 써라. 그래야 CPU를 다른 프로세스들에게 양보한다. */
+        timer_sleep(ticks);
+    }
+    else
+    {
+        /* Otherwise, use a busy-wait loop for more accurate
+           sub-tick tim to ing.  We scale the numerator and denominator
+           down by 1000avoid the possibility of overflow. */
+        ASSERT(denom % 1000 == 0);
+        busy_wait(loops_per_tick * num / 1000 * TIMER_FREQ / (denom / 1000));
+    }
 }

--- a/devices/timer.c
+++ b/devices/timer.c
@@ -41,18 +41,18 @@ static void real_time_sleep(int64_t num, int32_t denom);
 
 void timer_init(void)
 {
-	/* 8254 input frequency divided by TIMER_FREQ, rounded to
-	   nearest.
+   /* 8254 input frequency divided by TIMER_FREQ, rounded to
+      nearest.
 
-	   8254 입력 빈도를 TIMER_FREQ로 나눈 값으로 가장 가까운 값으로 반올림합니다.
-	   */
-	uint16_t count = (1193180 + TIMER_FREQ / 2) / TIMER_FREQ;
+      8254 입력 빈도를 TIMER_FREQ로 나눈 값으로 가장 가까운 값으로 반올림합니다.
+      */
+   uint16_t count = (1193180 + TIMER_FREQ / 2) / TIMER_FREQ;
 
-	outb(0x43, 0x34); /* CW: counter 0, LSB then MSB, mode 2, binary. */
-	outb(0x40, count & 0xff);
-	outb(0x40, count >> 8);
+   outb(0x43, 0x34); /* CW: counter 0, LSB then MSB, mode 2, binary. */
+   outb(0x40, count & 0xff);
+   outb(0x40, count >> 8);
 
-	intr_register_ext(0x20, timer_interrupt, "8254 Timer");
+   intr_register_ext(0x20, timer_interrupt, "8254 Timer");
 }
 
 /* Calibrates loops_per_tick, used to implement brief delays.
@@ -60,54 +60,54 @@ void timer_init(void)
 
 void timer_calibrate(void)
 {
-	unsigned high_bit, test_bit;
+   unsigned high_bit, test_bit;
 
-	ASSERT(intr_get_level() == INTR_ON);
-	printf("Calibrating timer...  ");
+   ASSERT(intr_get_level() == INTR_ON);
+   printf("Calibrating timer...  ");
 
-	/* Approximate loops_per_tick as the largest power-of-two
-	   still less than one timer tick.
-	   loops_per_tick을 타이머 틱보다 작은 가장 큰 2의 거듭제곱으로 대략적으로 설정합니다.
-	   */
-	loops_per_tick = 1u << 10;
-	while (!too_many_loops(loops_per_tick << 1))
-	{
-		loops_per_tick <<= 1;
-		ASSERT(loops_per_tick != 0);
-	}
+   /* Approximate loops_per_tick as the largest power-of-two
+      still less than one timer tick.
+      loops_per_tick을 타이머 틱보다 작은 가장 큰 2의 거듭제곱으로 대략적으로 설정합니다.
+      */
+   loops_per_tick = 1u << 10;
+   while (!too_many_loops(loops_per_tick << 1))
+   {
+      loops_per_tick <<= 1;
+      ASSERT(loops_per_tick != 0);
+   }
 
-	/* Refine the next 8 bits of loops_per_tick.
-	   loops_per_tick의 다음 8비트를 보정합니다.
-	*/
-	high_bit = loops_per_tick;
-	for (test_bit = high_bit >> 1; test_bit != high_bit >> 10; test_bit >>= 1)
-		if (!too_many_loops(high_bit | test_bit))
-			loops_per_tick |= test_bit;
+   /* Refine the next 8 bits of loops_per_tick.
+      loops_per_tick의 다음 8비트를 보정합니다.
+   */
+   high_bit = loops_per_tick;
+   for (test_bit = high_bit >> 1; test_bit != high_bit >> 10; test_bit >>= 1)
+      if (!too_many_loops(high_bit | test_bit))
+         loops_per_tick |= test_bit;
 
-	printf("%'" PRIu64 " loops/s.\n", (uint64_t)loops_per_tick * TIMER_FREQ);
+   printf("%'" PRIu64 " loops/s.\n", (uint64_t)loops_per_tick * TIMER_FREQ);
 }
 
 /* Returns the number of timer ticks since the OS booted.
-	OS가 부팅된 이후의 타이머 틱 수를 반환합니다.
+   OS가 부팅된 이후의 타이머 틱 수를 반환합니다.
 */
 int64_t
 timer_ticks(void)
 {
-	enum intr_level old_level = intr_disable(); // '이전 인터럽트 상태'를 인터럽트 불가로 설정?
-	int64_t t = ticks;							// OS가 부팅된 이후 타이머의 틱 수를 t에 저장
-	intr_set_level(old_level);					// 현재 인터럽트 레벨을 이전 인터럽트 상태로 설정
-	barrier();
-	return t;
+   enum intr_level old_level = intr_disable(); // '이전 인터럽트 상태'를 인터럽트 불가로 설정?
+   int64_t t = ticks;                          // OS가 부팅된 이후 타이머의 틱 수를 t에 저장
+   intr_set_level(old_level);                  // 현재 인터럽트 레벨을 이전 인터럽트 상태로 설정
+   barrier();
+   return t;
 } // 시간을 반환
 
 /* Returns the number of timer ticks elapsed since THEN, which
    should be a value once returned by timer_ticks().
-	THEN 이후에 경과한 타이머 틱 수를 반환합니다. 이 값은 timer_ticks()로 반환된 값이어야 합니다.
+   THEN 이후에 경과한 타이머 틱 수를 반환합니다. 이 값은 timer_ticks()로 반환된 값이어야 합니다.
 */
 int64_t
 timer_elapsed(int64_t then)
 {
-	return timer_ticks() - then;
+   return timer_ticks() - then;
 }
 
 /* Suspends execution for approximately TICKS timer ticks. */
@@ -124,52 +124,63 @@ timer_elapsed(int64_t then)
 /* 쓰레드를 sleep_list에 넣는 함수 */
 void timer_sleep(int64_t ticks)
 {
-	int64_t start = timer_ticks();
+   int64_t start = timer_ticks();
 
-	if (timer_elapsed(start) < ticks)
-	{
-		ASSERT(intr_get_level() == INTR_ON); // 인터럽트가 켜져 있어야 합니다.
-		thread_sleep(start + ticks);		 // 현재까지의 OS 시간 + 재우고 싶은 시간
-	}
+   if (timer_elapsed(start) < ticks)
+   {
+      ASSERT(intr_get_level() == INTR_ON); // 인터럽트가 켜져 있어야 합니다.
+      thread_sleep(start + ticks);         // 현재까지의 OS 시간 + 재우고 싶은 시간
+   }
 }
 
 /* Suspends execution for approximately MS milliseconds.
-	대략적으로 MS 밀리초 동안 실행을 중단합니다. */
+   대략적으로 MS 밀리초 동안 실행을 중단합니다. */
 void timer_msleep(int64_t ms)
 {
-	real_time_sleep(ms, 1000);
+   real_time_sleep(ms, 1000);
 }
 
 /* Suspends execution for approximately US microseconds.
-	대략적으로 US 마이크로초 동안 실행을 중단합니다. */
+   대략적으로 US 마이크로초 동안 실행을 중단합니다. */
 void timer_usleep(int64_t us)
 {
-	real_time_sleep(us, 1000 * 1000);
+   real_time_sleep(us, 1000 * 1000);
 }
 
 /* Suspends execution for approximately NS nanoseconds.
-	대략적으로 NS 나노초 동안 실행을 중단합니다. */
+   대략적으로 NS 나노초 동안 실행을 중단합니다. */
 void timer_nsleep(int64_t ns)
 {
-	real_time_sleep(ns, 1000 * 1000 * 1000);
+   real_time_sleep(ns, 1000 * 1000 * 1000);
 }
 
 /* Prints timer statistics.
-	타이머 통계를 출력합니다. */
+   타이머 통계를 출력합니다. */
 void timer_print_stats(void)
 {
-	printf("Timer: %" PRId64 " ticks\n", timer_ticks());
+   printf("Timer: %" PRId64 " ticks\n", timer_ticks());
 }
 
 /* Timer interrupt handler.
-	타이머 인터럽트 핸들러입니다. */
+   타이머 인터럽트 핸들러입니다. */
 static void
 timer_interrupt(struct intr_frame *args UNUSED)
 {
-	ticks++;
-	thread_tick();
+   ticks++;
+   thread_tick();
 
-	thread_wakeup(ticks);
+   thread_wakeup(ticks);
+
+   // 1초마다 재계산   1초에 100틱 = TIMER_FREQ
+   if (timer_ticks() % TIMER_FREQ == 0)
+   {
+      calc_load_avg();
+      calc_recent_cpu();
+   }
+
+   // 4틱마다 재계산
+   if (timer_ticks() % 4 == 0)
+      calc_priority();
 }
 
 /* Returns true if LOOPS iterations waits for more than one timer
@@ -179,21 +190,21 @@ timer_interrupt(struct intr_frame *args UNUSED)
 static bool
 too_many_loops(unsigned loops)
 {
-    /* Wait for a timer tick. */
-    int64_t start = ticks; // 현 sys 시간의 틱누계값을 start로 삼고,
-    while (ticks == start) // while과 바로윗줄의 명령이 순식간에 실행되어서, ticks값이
-                           // 차이가 없다면 아무것도 안하긴 하는데 일단 작동하게 해라. 쨋든 ticks가 증가하면
-                           // while문 탈출
-        barrier();
+   /* Wait for a timer tick. */
+   int64_t start = ticks; // 현 sys 시간의 틱누계값을 start로 삼고,
+   while (ticks == start) // while과 바로윗줄의 명령이 순식간에 실행되어서, ticks값이
+                          // 차이가 없다면 아무것도 안하긴 하는데 일단 작동하게 해라. 쨋든 ticks가 증가하면
+                          // while문 탈출
+      barrier();
 
-    /* Run LOOPS loops.
-        특정 루프를(loops) 반복(LOOPS) 한다. */
-    start = ticks;    // ticks를 다시 start로 삼고
-    busy_wait(loops); //  loops를 인자로 busy_wait를 해라?
+   /* Run LOOPS loops.
+       특정 루프를(loops) 반복(LOOPS) 한다. */
+   start = ticks;    // ticks를 다시 start로 삼고
+   busy_wait(loops); //  loops를 인자로 busy_wait를 해라?
 
-    /* If the tick count changed, we iterated too long. */
-    barrier();
-    return start != ticks;
+   /* If the tick count changed, we iterated too long. */
+   barrier();
+   return start != ticks;
 }
 
 /* Iterates through a simple loop LOOPS times, for implementing
@@ -209,9 +220,9 @@ too_many_loops(unsigned loops)
 static void NO_INLINE
 busy_wait(int64_t loops)
 {
-    while (loops-- > 0) // loops가 0인지 측정하고 라인나갈때 loops를 하나뺀다.
-        barrier();      // barrier는 아무것도 안하므로, 계속 빼다가 loops가 0이되면 탈출한다.
-    // 이것은 단지 딜레이의 구현을 위해 쓰여졌다?
+   while (loops-- > 0) // loops가 0인지 측정하고 라인나갈때 loops를 하나뺀다.
+      barrier();       // barrier는 아무것도 안하므로, 계속 빼다가 loops가 0이되면 탈출한다.
+                       // 이것은 단지 딜레이의 구현을 위해 쓰여졌다?
 }
 
 /* Sleep for approximately NUM/DENOM seconds.
@@ -219,32 +230,32 @@ busy_wait(int64_t loops)
 static void
 real_time_sleep(int64_t num, int32_t denom)
 {
-    /* Convert NUM/DENOM seconds into timer ticks, rounding down.
-        버림하여, 숫자/분모 초를 타이머의 틱 단위로 바꾼다.
+   /* Convert NUM/DENOM seconds into timer ticks, rounding down.
+       버림하여, 숫자/분모 초를 타이머의 틱 단위로 바꾼다.
 
-       (NUM / DENOM) s
-       ---------------------- = NUM * TIMER_FREQ / DENOM ticks.
-       1 s / TIMER_FREQ(타이머가 초당 인터럽트 하는 횟수) ticks
+      (NUM / DENOM) s
+      ---------------------- = NUM * TIMER_FREQ / DENOM ticks.
+      1 s / TIMER_FREQ(타이머가 초당 인터럽트 하는 횟수) ticks
 
-       */
-    int64_t ticks = num * TIMER_FREQ / denom;
-    // ticks를 할당한다.
+      */
+   int64_t ticks = num * TIMER_FREQ / denom;
+   // ticks를 할당한다.
 
-    ASSERT(intr_get_level() == INTR_ON); //  인터럽트가 켜져야 진행된다.
-    if (ticks > 0)
-    {
-        /* We're waiting for at least one full timer tick.  Use
-           timer_sleep() because it will yield the CPU to other
-           processes.
-           timer_sleep()을 써라. 그래야 CPU를 다른 프로세스들에게 양보한다. */
-        timer_sleep(ticks);
-    }
-    else
-    {
-        /* Otherwise, use a busy-wait loop for more accurate
-           sub-tick tim to ing.  We scale the numerator and denominator
-           down by 1000avoid the possibility of overflow. */
-        ASSERT(denom % 1000 == 0);
-        busy_wait(loops_per_tick * num / 1000 * TIMER_FREQ / (denom / 1000));
-    }
+   ASSERT(intr_get_level() == INTR_ON); //  인터럽트가 켜져야 진행된다.
+   if (ticks > 0)
+   {
+      /* We're waiting for at least one full timer tick.  Use
+         timer_sleep() because it will yield the CPU to other
+         processes.
+         timer_sleep()을 써라. 그래야 CPU를 다른 프로세스들에게 양보한다. */
+      timer_sleep(ticks);
+   }
+   else
+   {
+      /* Otherwise, use a busy-wait loop for more accurate
+         sub-tick tim to ing.  We scale the numerator and denominator
+         down by 1000avoid the possibility of overflow. */
+      ASSERT(denom % 1000 == 0);
+      busy_wait(loops_per_tick * num / 1000 * TIMER_FREQ / (denom / 1000));
+   }
 }

--- a/devices/timer.c
+++ b/devices/timer.c
@@ -170,6 +170,16 @@ timer_interrupt(struct intr_frame *args UNUSED)
     thread_tick();
 
     thread_wakeup(ticks);
+
+    if (timer_ticks() % TIMER_FREQ == 0)
+    {
+        calc_load_avg();
+        // calc_recent_cpu();
+    }
+    // if (timer_ticks() % 4 == 0)
+    // {
+    //     calc_priority();
+    // }
 }
 
 /* Returns true if LOOPS iterations waits for more than one timer

--- a/devices/timer.c
+++ b/devices/timer.c
@@ -173,13 +173,13 @@ timer_interrupt(struct intr_frame *args UNUSED)
 
     if (!thread_mlfqs)
         return;
-    if (timer_ticks() % TIMER_FREQ == 0)
-    {
-        calc_load_avg();
-        // calc_all_recent_cpu();
-    }
     if (timer_ticks() % 4 == 0)
     {
+        if (timer_ticks() % TIMER_FREQ == 0)
+        {
+            calc_load_avg();
+            calc_all_recent_cpu();
+        }
         calc_all_priority();
     }
 }

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -102,7 +102,7 @@ struct thread
 	int original;
 
 	int nice; // -20 ~ 20
-	double recent_cpu;
+	int recent_cpu;
 
 	struct lock *wait_on_lock;
 
@@ -159,8 +159,8 @@ void thread_set_nice(int);
 int thread_get_recent_cpu(void);
 int thread_get_load_avg(void);
 
-int calc_load_avg();
-int calc_recent_cpu();
+void calc_load_avg();
+void calc_recent_cpu();
 int calc_priority();
 
 void do_iret(struct intr_frame *tf);

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -101,6 +101,9 @@ struct thread
 	int priority;			   /* Priority. */
 	int original;
 
+	int nice; // -20 ~ 20
+	double recent_cpu;
+
 	struct lock *wait_on_lock;
 
 	/* Shared between thread.c and synch.c. */
@@ -153,6 +156,10 @@ int thread_get_nice(void);
 void thread_set_nice(int);
 int thread_get_recent_cpu(void);
 int thread_get_load_avg(void);
+
+int calc_load_avg();
+int calc_recent_cpu();
+int calc_priority();
 
 void do_iret(struct intr_frame *tf);
 

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -160,8 +160,8 @@ int thread_get_recent_cpu(void);
 int thread_get_load_avg(void);
 
 void calc_load_avg();
-void calc_recent_cpu();
-int calc_priority();
+void calc_all_recent_cpu();
+void calc_all_priority();
 
 void do_iret(struct intr_frame *tf);
 

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -105,10 +105,11 @@ struct thread
     int recent_cpu;
 
     struct lock *wait_on_lock;
+    struct list donations; // 기부해준 스레드
 
     /* Shared between thread.c and synch.c. */
     struct list_elem elem; /* List element. */
-
+    struct list_elem d_elem;
     struct list_elem th_elem; // thread_list
 
 #ifdef USERPROG
@@ -159,9 +160,12 @@ void thread_set_nice(int);
 int thread_get_recent_cpu(void);
 int thread_get_load_avg(void);
 
-void calc_load_avg();
-void calc_all_recent_cpu();
-void calc_all_priority();
+void calc_load_avg(void);
+void calc_all_recent_cpu(void);
+void calc_all_priority(void);
+int calc_recent_cpu(struct thread *th);
+int calc_one_priority(struct thread *t);
+void increase_recent_cpu(struct thread *th);
 
 void do_iret(struct intr_frame *tf);
 
@@ -169,6 +173,7 @@ void thread_wakeup(int64_t ticks);
 void thread_sleep(int64_t sleep_time);
 
 bool priority(const struct list_elem *a, const struct list_elem *b, void *aux);
+bool d_elem_priority(const struct list_elem *a, const struct list_elem *b, void *aux);
 
 void thread_preempt(void);
 

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -102,11 +102,9 @@ struct thread
 	int original;
 
 	struct lock *wait_on_lock;
-	struct list donations; // 기부해준 스레드
 
 	/* Shared between thread.c and synch.c. */
 	struct list_elem elem; /* List element. */
-	struct list_elem d_elem;
 
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */
@@ -162,7 +160,6 @@ void thread_wakeup(int64_t ticks);
 void thread_sleep(int64_t sleep_time);
 
 bool priority(const struct list_elem *a, const struct list_elem *b, void *aux);
-bool d_elem_priority(const struct list_elem *a, const struct list_elem *b, void *aux);
 
 void thread_preempt(void);
 

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -12,10 +12,10 @@
 /* States in a thread's life cycle. */
 enum thread_status
 {
-	THREAD_RUNNING, /* Running thread. */
-	THREAD_READY,	/* Not running but ready to run. */
-	THREAD_BLOCKED, /* Waiting for an event to trigger. */
-	THREAD_DYING,	/* About to be destroyed. */
+    THREAD_RUNNING, /* Running thread. */
+    THREAD_READY,   /* Not running but ready to run. */
+    THREAD_BLOCKED, /* Waiting for an event to trigger. */
+    THREAD_DYING,   /* About to be destroyed. */
 };
 
 /* Thread identifier type.
@@ -24,9 +24,9 @@ typedef int tid_t;
 #define TID_ERROR ((tid_t)-1) /* Error value for tid_t. */
 
 /* Thread priorities. */
-#define PRI_MIN 0	   /* Lowest priority. */
+#define PRI_MIN 0      /* Lowest priority. */
 #define PRI_DEFAULT 31 /* Default priority. */
-#define PRI_MAX 63	   /* Highest priority. */
+#define PRI_MAX 63     /* Highest priority. */
 
 /* A kernel thread or user process.
  *
@@ -94,37 +94,37 @@ typedef int tid_t;
  * 에 있습니다. */
 struct thread
 {
-	/* Owned by thread.c. */
-	tid_t tid;				   /* Thread identifier. */
-	enum thread_status status; /* Thread state. */
-	char name[16];			   /* Name (for debugging purposes). */
-	int priority;			   /* Priority. */
-	int original;
+    /* Owned by thread.c. */
+    tid_t tid;                 /* Thread identifier. */
+    enum thread_status status; /* Thread state. */
+    char name[16];             /* Name (for debugging purposes). */
+    int priority;              /* Priority. */
+    int original;
 
-	int nice; // -20 ~ 20
-	int recent_cpu;
+    int nice; // -20 ~ 20
+    int recent_cpu;
 
-	struct lock *wait_on_lock;
+    struct lock *wait_on_lock;
 
-	/* Shared between thread.c and synch.c. */
-	struct list_elem elem; /* List element. */
+    /* Shared between thread.c and synch.c. */
+    struct list_elem elem; /* List element. */
 
-	struct list_elem th_elem; // thread_list
+    struct list_elem th_elem; // thread_list
 
 #ifdef USERPROG
-	/* Owned by userprog/process.c. */
-	uint64_t *pml4; /* Page map level 4 */
+    /* Owned by userprog/process.c. */
+    uint64_t *pml4; /* Page map level 4 */
 
 #endif
 #ifdef VM
-	/* Table for whole virtual memory owned by thread. */
-	struct supplemental_page_table spt;
+    /* Table for whole virtual memory owned by thread. */
+    struct supplemental_page_table spt;
 #endif
 
-	/* Owned by thread.c. */
-	struct intr_frame tf; /* Information for switching */
-	unsigned magic;		  /* Detects stack overflow. */
-	int64_t wakeup_tick;  /* 쓰레드가 wake-up할 tick(local tick)*/
+    /* Owned by thread.c. */
+    struct intr_frame tf; /* Information for switching */
+    unsigned magic;       /* Detects stack overflow. */
+    int64_t wakeup_tick;  /* 쓰레드가 wake-up할 tick(local tick)*/
 };
 
 /* If false (default), use round-robin scheduler.

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -109,6 +109,8 @@ struct thread
 	/* Shared between thread.c and synch.c. */
 	struct list_elem elem; /* List element. */
 
+	struct list_elem th_elem; // thread_list
+
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */
 	uint64_t *pml4; /* Page map level 4 */

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -163,7 +163,8 @@ void sema_up(struct semaphore *sema)
 		thread_unblock(popth);
 	}
 	sema->value++;
-	thread_preempt();
+
+	thread_yield(); // thread_preempt();
 	intr_set_level(old_level);
 }
 
@@ -413,7 +414,7 @@ void cond_signal(struct condition *cond, struct lock *lock)
 	if (!list_empty(&cond->waiters))
 	{ // 맨 앞에 애한테 알림
 		list_sort(&cond->waiters, cond_priority, NULL);
-		struct list_elem *e = list_entry(list_front(&cond->waiters), struct semaphore_elem, elem);
+		// struct list_elem *e = list_entry(list_front(&cond->waiters), struct semaphore_elem, elem);
 		sema_up(&list_entry(list_pop_front(&cond->waiters),
 							struct semaphore_elem, elem)
 					 ->semaphore);

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -48,10 +48,10 @@ void donate_priority(struct list_elem *donor, struct thread *holder);
    thread, if any). */
 void sema_init(struct semaphore *sema, unsigned value)
 {
-	ASSERT(sema != NULL);
+    ASSERT(sema != NULL);
 
-	sema->value = value;
-	list_init(&sema->waiters);
+    sema->value = value;
+    list_init(&sema->waiters);
 }
 
 /* Down or "P" operation on a semaphore.  Waits for SEMA's value
@@ -70,20 +70,20 @@ void sema_init(struct semaphore *sema, unsigned value)
 아마도 인터럽트를 다시 활성화할 것입니다. 이것은 sema_down 함수입니다. */
 void sema_down(struct semaphore *sema)
 {
-	enum intr_level old_level;
+    enum intr_level old_level;
 
-	ASSERT(sema != NULL);
-	ASSERT(!intr_context());
+    ASSERT(sema != NULL);
+    ASSERT(!intr_context());
 
-	old_level = intr_disable();
-	while (sema->value == 0)
-	{
-		list_push_back(&sema->waiters, &thread_current()->elem);
-		// list_insert_ordered(&sema->waiters, &thread_current()->elem, priority, NULL);
-		thread_block(); // 실행 정지
-	}
-	sema->value--;
-	intr_set_level(old_level);
+    old_level = intr_disable();
+    while (sema->value == 0)
+    {
+        list_push_back(&sema->waiters, &thread_current()->elem);
+        // list_insert_ordered(&sema->waiters, &thread_current()->elem, priority, NULL);
+        thread_block(); // 실행 정지
+    }
+    sema->value--;
+    intr_set_level(old_level);
 }
 
 /* Down or "P" operation on a semaphore, but only if the
@@ -93,22 +93,22 @@ void sema_down(struct semaphore *sema)
    This function may be called from an interrupt handler. */
 bool sema_try_down(struct semaphore *sema)
 {
-	enum intr_level old_level;
-	bool success;
+    enum intr_level old_level;
+    bool success;
 
-	ASSERT(sema != NULL);
+    ASSERT(sema != NULL);
 
-	old_level = intr_disable();
-	if (sema->value > 0)
-	{
-		sema->value--;
-		success = true;
-	}
-	else
-		success = false;
-	intr_set_level(old_level);
+    old_level = intr_disable();
+    if (sema->value > 0)
+    {
+        sema->value--;
+        success = true;
+    }
+    else
+        success = false;
+    intr_set_level(old_level);
 
-	return success;
+    return success;
 }
 
 /* Up or "V" operation on a semaphore.  Increments SEMA's value
@@ -117,24 +117,24 @@ bool sema_try_down(struct semaphore *sema)
    This function may be called from an interrupt handler. */
 void sema_up(struct semaphore *sema)
 {
-	enum intr_level old_level;
+    enum intr_level old_level;
 
-	ASSERT(sema != NULL);
+    ASSERT(sema != NULL);
 
-	old_level = intr_disable();
-	if (!list_empty(&sema->waiters))
-	{
-		struct thread *curr = thread_current();
+    old_level = intr_disable();
+    if (!list_empty(&sema->waiters))
+    {
+        struct thread *curr = thread_current();
 
-		list_sort(&sema->waiters, priority, NULL);
-		struct thread *popth = list_entry(list_pop_front(&sema->waiters),
-										  struct thread, elem);
-		thread_unblock(popth);
-	}
-	sema->value++;
+        list_sort(&sema->waiters, priority, NULL);
+        struct thread *popth = list_entry(list_pop_front(&sema->waiters),
+                                          struct thread, elem);
+        thread_unblock(popth);
+    }
+    sema->value++;
 
-	thread_yield(); // thread_preempt();
-	intr_set_level(old_level);
+    thread_yield(); // thread_preempt();
+    intr_set_level(old_level);
 }
 
 static void sema_test_helper(void *sema_);
@@ -144,33 +144,33 @@ static void sema_test_helper(void *sema_);
    what's going on. */
 void sema_self_test(void)
 {
-	struct semaphore sema[2];
-	int i;
+    struct semaphore sema[2];
+    int i;
 
-	printf("Testing semaphores...");
-	sema_init(&sema[0], 0);
-	sema_init(&sema[1], 0);
-	thread_create("sema-test", PRI_DEFAULT, sema_test_helper, &sema);
-	for (i = 0; i < 10; i++)
-	{
-		sema_up(&sema[0]);
-		sema_down(&sema[1]);
-	}
-	printf("done.\n");
+    printf("Testing semaphores...");
+    sema_init(&sema[0], 0);
+    sema_init(&sema[1], 0);
+    thread_create("sema-test", PRI_DEFAULT, sema_test_helper, &sema);
+    for (i = 0; i < 10; i++)
+    {
+        sema_up(&sema[0]);
+        sema_down(&sema[1]);
+    }
+    printf("done.\n");
 }
 
 /* Thread function used by sema_self_test(). */
 static void
 sema_test_helper(void *sema_)
 {
-	struct semaphore *sema = sema_;
-	int i;
+    struct semaphore *sema = sema_;
+    int i;
 
-	for (i = 0; i < 10; i++)
-	{
-		sema_down(&sema[0]);
-		sema_up(&sema[1]);
-	}
+    for (i = 0; i < 10; i++)
+    {
+        sema_down(&sema[0]);
+        sema_up(&sema[1]);
+    }
 }
 
 /* Initializes LOCK.  A lock can be held by at most a single
@@ -178,8 +178,8 @@ sema_test_helper(void *sema_)
    is, it is an error for the thread currently holding a lock to
    try to acquire that lock.
 LOCK을 초기화합니다. 한 번에 최대 한 개의 스레드만이 잠금을 보유할 수 있습니다.
-	우리의 잠금은 "재귀적"이지 않습니다. 즉, 현재 잠금을 보유하고 있는 스레드가
-	그 잠금을 다시 획득하려고 시도하는 것은 오류입니다.
+    우리의 잠금은 "재귀적"이지 않습니다. 즉, 현재 잠금을 보유하고 있는 스레드가
+    그 잠금을 다시 획득하려고 시도하는 것은 오류입니다.
 
    A lock is a specialization of a semaphore with an initial
    value of 1.  The difference between a lock and such a
@@ -200,40 +200,40 @@ LOCK을 초기화합니다. 한 번에 최대 한 개의 스레드만이 잠금�
    */
 void lock_init(struct lock *lock)
 {
-	ASSERT(lock != NULL);
+    ASSERT(lock != NULL);
 
-	lock->holder = NULL;
-	sema_init(&lock->semaphore, 1);
+    lock->holder = NULL;
+    sema_init(&lock->semaphore, 1);
 }
 
 /* Acquires LOCK, sleeping until it becomes available if
    necessary.  The lock must not already be held by the current
    thread.
 잠금키를 얻습니다. 획득이 당장 안되면 사용 가능할 때 까지 잠듭니다.
-	이 잠금키는 현재쓰레드가 이미보유하고 있지 않아야 합니다. (이잠금키를 현재의쓰레드가
-	보유하는 상황이 벌어져서는 안됩니다.)
+    이 잠금키는 현재쓰레드가 이미보유하고 있지 않아야 합니다. (이잠금키를 현재의쓰레드가
+    보유하는 상황이 벌어져서는 안됩니다.)
    This function may sleep, so it must not be called within an
    interrupt handler.  This function may be called with
    interrupts disabled, but interrupts will be turned back on if
    we need to sleep.
-	이 함수는 잠에 들 수도 있어서, 인터럽트 핸들러 내에서는 절대 실행되서는 안됩니다.
-	(인터럽트 핸들러는 항상 동작해야 하므로) 인터럽트 비활성화 상태에서는 호출할 수
-	있지만, 잠에 들어야 할경우, 인터럽트가 다시 켜질겁니다.
+    이 함수는 잠에 들 수도 있어서, 인터럽트 핸들러 내에서는 절대 실행되서는 안됩니다.
+    (인터럽트 핸들러는 항상 동작해야 하므로) 인터럽트 비활성화 상태에서는 호출할 수
+    있지만, 잠에 들어야 할경우, 인터럽트가 다시 켜질겁니다.
    */
 void lock_acquire(struct lock *lock)
 {
-	ASSERT(lock != NULL);
-	ASSERT(!intr_context());
-	ASSERT(!lock_held_by_current_thread(lock));
+    ASSERT(lock != NULL);
+    ASSERT(!intr_context());
+    ASSERT(!lock_held_by_current_thread(lock));
 
-	if (lock->holder != NULL)
-	{
-		thread_current()->wait_on_lock = lock;
-	}
-	sema_down(&lock->semaphore);
-	lock->holder = thread_current();
-	if (thread_current()->wait_on_lock != NULL)
-		thread_current()->wait_on_lock = NULL;
+    if (lock->holder != NULL)
+    {
+        thread_current()->wait_on_lock = lock;
+    }
+    sema_down(&lock->semaphore);
+    lock->holder = thread_current();
+    if (thread_current()->wait_on_lock != NULL)
+        thread_current()->wait_on_lock = NULL;
 }
 
 /* Tries to acquires LOCK and returns true if successful or false
@@ -244,15 +244,15 @@ void lock_acquire(struct lock *lock)
    interrupt handler. */
 bool lock_try_acquire(struct lock *lock)
 {
-	bool success;
+    bool success;
 
-	ASSERT(lock != NULL);
-	ASSERT(!lock_held_by_current_thread(lock));
+    ASSERT(lock != NULL);
+    ASSERT(!lock_held_by_current_thread(lock));
 
-	success = sema_try_down(&lock->semaphore);
-	if (success)
-		lock->holder = thread_current();
-	return success;
+    success = sema_try_down(&lock->semaphore);
+    if (success)
+        lock->holder = thread_current();
+    return success;
 }
 
 /* Releases LOCK, which must be owned by the current thread.
@@ -263,11 +263,11 @@ bool lock_try_acquire(struct lock *lock)
    handler. */
 void lock_release(struct lock *lock)
 {
-	ASSERT(lock != NULL);
-	ASSERT(lock_held_by_current_thread(lock));
+    ASSERT(lock != NULL);
+    ASSERT(lock_held_by_current_thread(lock));
 
-	lock->holder = NULL;
-	sema_up(&lock->semaphore);
+    lock->holder = NULL;
+    sema_up(&lock->semaphore);
 }
 
 /* Returns true if the current thread holds LOCK, false
@@ -276,18 +276,18 @@ void lock_release(struct lock *lock)
    현재 쓰레드가 잠금키( lock)을 갖고 있다면 true를 반환, 아닌경우 false반환. */
 bool lock_held_by_current_thread(const struct lock *lock)
 {
-	ASSERT(lock != NULL);
+    ASSERT(lock != NULL);
 
-	return lock->holder == thread_current(); // 현재 쓰레드가 lo
+    return lock->holder == thread_current(); // 현재 쓰레드가 lo
 }
 
 /* One semaphore in a list. */
 struct semaphore_elem
 {
-	struct list_elem elem;		/* List element. */
-	struct semaphore semaphore; /* This semaphore. */
+    struct list_elem elem;      /* List element. */
+    struct semaphore semaphore; /* This semaphore. */
 
-	int priority;
+    int priority;
 };
 
 /* Initializes condition variable COND.  A condition variable
@@ -295,9 +295,9 @@ struct semaphore_elem
    code to receive the signal and act upon it. */
 void cond_init(struct condition *cond)
 {
-	ASSERT(cond != NULL);
+    ASSERT(cond != NULL);
 
-	list_init(&cond->waiters);
+    list_init(&cond->waiters);
 }
 
 /* Atomically releases LOCK and waits for COND to be signaled by
@@ -322,20 +322,20 @@ void cond_init(struct condition *cond)
    we need to sleep. */
 void cond_wait(struct condition *cond, struct lock *lock)
 {
-	struct semaphore_elem waiter;
+    struct semaphore_elem waiter;
 
-	ASSERT(cond != NULL);
-	ASSERT(lock != NULL);
-	ASSERT(!intr_context());
-	ASSERT(lock_held_by_current_thread(lock));
+    ASSERT(cond != NULL);
+    ASSERT(lock != NULL);
+    ASSERT(!intr_context());
+    ASSERT(lock_held_by_current_thread(lock));
 
-	sema_init(&waiter.semaphore, 0);
-	waiter.priority = lock->holder->priority;
-	list_push_back(&cond->waiters, &waiter.elem);
-	// list_insert_ordered(&cond->waiters, &waiter.elem, priority, NULL);
-	lock_release(lock);
-	sema_down(&waiter.semaphore);
-	lock_acquire(lock);
+    sema_init(&waiter.semaphore, 0);
+    waiter.priority = lock->holder->priority;
+    list_push_back(&cond->waiters, &waiter.elem);
+    // list_insert_ordered(&cond->waiters, &waiter.elem, priority, NULL);
+    lock_release(lock);
+    sema_down(&waiter.semaphore);
+    lock_acquire(lock);
 }
 
 /* If any threads are waiting on COND (protected by LOCK), then
@@ -347,27 +347,27 @@ void cond_wait(struct condition *cond, struct lock *lock)
    interrupt handler. */
 bool cond_priority(const struct list_elem *a, const struct list_elem *b, void *aux)
 {
-	struct semaphore_elem *sa = list_entry(a, struct semaphore_elem, elem);
-	struct semaphore_elem *sb = list_entry(b, struct semaphore_elem, elem);
+    struct semaphore_elem *sa = list_entry(a, struct semaphore_elem, elem);
+    struct semaphore_elem *sb = list_entry(b, struct semaphore_elem, elem);
 
-	return sa->priority > sb->priority;
+    return sa->priority > sb->priority;
 }
 
 void cond_signal(struct condition *cond, struct lock *lock)
 {
-	ASSERT(cond != NULL);
-	ASSERT(lock != NULL);
-	ASSERT(!intr_context());
-	ASSERT(lock_held_by_current_thread(lock));
+    ASSERT(cond != NULL);
+    ASSERT(lock != NULL);
+    ASSERT(!intr_context());
+    ASSERT(lock_held_by_current_thread(lock));
 
-	if (!list_empty(&cond->waiters))
-	{ // 맨 앞에 애한테 알림
-		list_sort(&cond->waiters, cond_priority, NULL);
-		// struct list_elem *e = list_entry(list_front(&cond->waiters), struct semaphore_elem, elem);
-		sema_up(&list_entry(list_pop_front(&cond->waiters),
-							struct semaphore_elem, elem)
-					 ->semaphore);
-	}
+    if (!list_empty(&cond->waiters))
+    { // 맨 앞에 애한테 알림
+        list_sort(&cond->waiters, cond_priority, NULL);
+        // struct list_elem *e = list_entry(list_front(&cond->waiters), struct semaphore_elem, elem);
+        sema_up(&list_entry(list_pop_front(&cond->waiters),
+                            struct semaphore_elem, elem)
+                     ->semaphore);
+    }
 }
 
 /* Wakes up all threads, if any, waiting on COND (protected by
@@ -378,9 +378,9 @@ void cond_signal(struct condition *cond, struct lock *lock)
    interrupt handler. */
 void cond_broadcast(struct condition *cond, struct lock *lock)
 {
-	ASSERT(cond != NULL);
-	ASSERT(lock != NULL);
+    ASSERT(cond != NULL);
+    ASSERT(lock != NULL);
 
-	while (!list_empty(&cond->waiters))
-		cond_signal(cond, lock);
+    while (!list_empty(&cond->waiters))
+        cond_signal(cond, lock);
 }

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -86,29 +86,6 @@ void sema_down(struct semaphore *sema)
 	intr_set_level(old_level);
 }
 
-// 기부자 리스트에서 가장 높은 우선순위 받아오기
-void donate_priority(struct list_elem *donor, struct thread *holder)
-{
-	// struct thread *donor = list_entry(list_front(&waiters->waiters), struct thread, elem);
-	list_insert_ordered(&holder->donations, donor, d_elem_priority, NULL);
-	int dona_prio = list_entry(list_front(&holder->donations), struct thread, d_elem)->priority;
-	if (holder->priority < dona_prio)
-	{
-		holder->priority = dona_prio;
-	}
-
-	while (holder->wait_on_lock != NULL)
-	{ // 다른 lock에 대해 기다리는 중이면
-		holder = holder->wait_on_lock->holder;
-		list_sort(&holder->donations, d_elem_priority, NULL);
-		int dona_prio = list_entry(list_front(&holder->donations), struct thread, d_elem)->priority;
-		if (holder->priority < dona_prio)
-		{
-			holder->priority = dona_prio;
-		}
-	}
-}
-
 /* Down or "P" operation on a semaphore, but only if the
    semaphore is not already 0.  Returns true if the semaphore is
    decremented, false otherwise.
@@ -147,16 +124,8 @@ void sema_up(struct semaphore *sema)
 	old_level = intr_disable();
 	if (!list_empty(&sema->waiters))
 	{
-		// printf("pri:%d  ori:%d\n", thread_current()->priority, thread_current()->original);
 		struct thread *curr = thread_current();
 
-		if (!list_empty(&curr->donations))
-		{
-			// list_sort(&curr->donations, d_elem_priority, NULL);
-			curr->priority = list_entry(list_front(&curr->donations), struct thread, d_elem)->priority;
-		}
-		else
-			thread_current()->priority = thread_current()->original;
 		list_sort(&sema->waiters, priority, NULL);
 		struct thread *popth = list_entry(list_pop_front(&sema->waiters),
 										  struct thread, elem);
@@ -260,11 +229,9 @@ void lock_acquire(struct lock *lock)
 	if (lock->holder != NULL)
 	{
 		thread_current()->wait_on_lock = lock;
-		donate_priority(&thread_current()->d_elem, lock->holder);
 	}
 	sema_down(&lock->semaphore);
 	lock->holder = thread_current();
-	// printf("holdrer tid  %d\n", lock->holder->tid);
 	if (thread_current()->wait_on_lock != NULL)
 		thread_current()->wait_on_lock = NULL;
 }
@@ -298,24 +265,6 @@ void lock_release(struct lock *lock)
 {
 	ASSERT(lock != NULL);
 	ASSERT(lock_held_by_current_thread(lock));
-
-	if (!list_empty(&lock->holder->donations))
-	{
-		struct list_elem *e = list_front(&lock->holder->donations);
-		while (e != NULL)
-		{
-			struct thread *t = list_entry(e, struct thread, d_elem);
-
-			if (t->wait_on_lock == lock)
-			{
-				list_remove(&t->d_elem);
-			}
-
-			e = e->next;
-			if (e->next == NULL)
-				break;
-		}
-	}
 
 	lock->holder = NULL;
 	sema_up(&lock->semaphore);

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -80,8 +80,6 @@ void sema_down(struct semaphore *sema)
 	{
 		list_push_back(&sema->waiters, &thread_current()->elem);
 		// list_insert_ordered(&sema->waiters, &thread_current()->elem, priority, NULL);
-		if (thread_current()->wait_on_lock != NULL)
-			donate_priority(&thread_current()->d_elem, thread_current()->wait_on_lock->holder);
 		thread_block(); // 실행 정지
 	}
 	sema->value--;
@@ -261,6 +259,7 @@ void lock_acquire(struct lock *lock)
 	if (lock->holder != NULL)
 	{
 		thread_current()->wait_on_lock = lock;
+		donate_priority(&thread_current()->d_elem, lock->holder);
 	}
 	sema_down(&lock->semaphore);
 	lock->holder = thread_current();
@@ -324,7 +323,7 @@ void lock_release(struct lock *lock)
 /* Returns true if the current thread holds LOCK, false
    otherwise.  (Note that testing whether some other thread holds
    a lock would be racy.)
-   현재 쓰레드가 잠금키(lock)을 갖고 있다면 true를 반환, 아닌경우 false반환. */
+   현재 쓰레드가 잠금키( lock)을 갖고 있다면 true를 반환, 아닌경우 false반환. */
 bool lock_held_by_current_thread(const struct lock *lock)
 {
 	ASSERT(lock != NULL);

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -328,6 +328,7 @@ tid_t thread_create(const char *name, int priority,
 	   실행 큐에 추가 */
 
 	thread_unblock(t);
+
 	struct thread *curr = running_thread();
 	int cur_priority = curr->priority;
 	// printf("tid : %d  T: %d\n", curr->priority, t->priority);

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -72,7 +72,7 @@ static long long kernel_ticks; /* 정적변수 ### of timer ticks in kernel thre
 static long long user_ticks;   /* 정적변수 ### of timer ticks in user programs. */
 
 /* Scheduling. */
-#define TIME_SLICE 4		  /* 스케줄링을 위한 간격 ### of timer ticks to give each thread. */
+#define TIME_SLICE 4          /* 스케줄링을 위한 간격 ### of timer ticks to give each thread. */
 static unsigned thread_ticks; /* 마지막 양보 부터의 타이머틱스 ### of timer ticks since last yield. */
 
 /* If false (default), use round-robin scheduler.
@@ -173,52 +173,52 @@ static uint64_t gdt[3] = {0, 0x00af9a000000ffff, 0x00cf92000000ffff};
 
 bool less(const struct list_elem *a, const struct list_elem *b, void *aux)
 {
-	struct thread *ta = list_entry(a, struct thread, elem);
-	struct thread *tb = list_entry(b, struct thread, elem);
+    struct thread *ta = list_entry(a, struct thread, elem);
+    struct thread *tb = list_entry(b, struct thread, elem);
 
-	return ta->wakeup_tick < tb->wakeup_tick;
+    return ta->wakeup_tick < tb->wakeup_tick;
 }
 
 bool priority(const struct list_elem *a, const struct list_elem *b, void *aux)
 {
-	struct thread *ta = list_entry(a, struct thread, elem);
-	struct thread *tb = list_entry(b, struct thread, elem);
+    struct thread *ta = list_entry(a, struct thread, elem);
+    struct thread *tb = list_entry(b, struct thread, elem);
 
-	return ta->priority > tb->priority;
+    return ta->priority > tb->priority;
 }
 
 void thread_init(void)
 {
-	ASSERT(intr_get_level() == INTR_OFF);
+    ASSERT(intr_get_level() == INTR_OFF);
 
-	/* Reload the temporal gdt for the kernel
-	 * This gdt does not include the user context.
-	 * The kernel will rebuild the gdt with user context, in gdt_init ().
-	 *
-	 * 커널을 위해 임시 gdt를 다시 로드합니다.
-	 * 이 gdt에는 사용자 컨텍스트가 포함되어 있지 않습니다.
-	 * 커널은 사용자 컨텍스트가 포함된 gdt를 gdt_init()에서 다시 만들 것입니다. */
-	struct desc_ptr gdt_ds = {
-		.size = sizeof(gdt) - 1,
-		.address = (uint64_t)gdt};
-	lgdt(&gdt_ds);
+    /* Reload the temporal gdt for the kernel
+     * This gdt does not include the user context.
+     * The kernel will rebuild the gdt with user context, in gdt_init ().
+     *
+     * 커널을 위해 임시 gdt를 다시 로드합니다.
+     * 이 gdt에는 사용자 컨텍스트가 포함되어 있지 않습니다.
+     * 커널은 사용자 컨텍스트가 포함된 gdt를 gdt_init()에서 다시 만들 것입니다. */
+    struct desc_ptr gdt_ds = {
+        .size = sizeof(gdt) - 1,
+        .address = (uint64_t)gdt};
+    lgdt(&gdt_ds);
 
-	/* Init the global thread context
-	   전역 스레드 컨텍스트 초기화 */
-	lock_init(&tid_lock);
-	list_init(&ready_list);
-	list_init(&sleep_list);
-	list_init(&thread_list);
-	list_init(&destruction_req);
+    /* Init the global thread context
+       전역 스레드 컨텍스트 초기화 */
+    lock_init(&tid_lock);
+    list_init(&ready_list);
+    list_init(&sleep_list);
+    list_init(&thread_list);
+    list_init(&destruction_req);
 
-	/* Set up a thread structure for the running thread.
-	   실행중인 쓰레드를 위한 쓰레드 구조를 설정 */
-	initial_thread = running_thread();
-	init_thread(initial_thread, "main", PRI_DEFAULT);
-	initial_thread->status = THREAD_RUNNING;
-	initial_thread->tid = allocate_tid();
+    /* Set up a thread structure for the running thread.
+       실행중인 쓰레드를 위한 쓰레드 구조를 설정 */
+    initial_thread = running_thread();
+    init_thread(initial_thread, "main", PRI_DEFAULT);
+    initial_thread->status = THREAD_RUNNING;
+    initial_thread->tid = allocate_tid();
 
-	load_avg = 0;
+    load_avg = 0;
 }
 
 /* Starts preemptive thread scheduling by enabling interrupts.
@@ -229,52 +229,52 @@ void thread_init(void)
    */
 void thread_start(void)
 {
-	/* Create the idle thread.
-	   유휴 스레드를 생성합니다. */
-	struct semaphore idle_started;
-	sema_init(&idle_started, 0);
-	thread_create("idle", PRI_MIN, idle, &idle_started);
+    /* Create the idle thread.
+       유휴 스레드를 생성합니다. */
+    struct semaphore idle_started;
+    sema_init(&idle_started, 0);
+    thread_create("idle", PRI_MIN, idle, &idle_started);
 
-	/* Start preemptive thread scheduling.
-	   선점형 스레드 스케줄링을 시작합니다. */
-	intr_enable();
+    /* Start preemptive thread scheduling.
+       선점형 스레드 스케줄링을 시작합니다. */
+    intr_enable();
 
-	/* Wait for the idle thread to initialize idle_thread.
-	   유휴 스레드가 idle_thread를 초기화 하기를 기다립니다. */
-	sema_down(&idle_started);
+    /* Wait for the idle thread to initialize idle_thread.
+       유휴 스레드가 idle_thread를 초기화 하기를 기다립니다. */
+    sema_down(&idle_started);
 }
 
 /* Called by the timer interrupt handler at each timer tick.
    Thus, this function runs in an external interrupt context.
-	매 타이머의 틱마다, 타이머 인터럽트 핸들러에 의해 불려진다.
+    매 타이머의 틱마다, 타이머 인터럽트 핸들러에 의해 불려진다.
    그래서, 이 함수는 external문맥(외부신호인터럽트)에서 실행된다.
    */
 void thread_tick(void)
 {
-	struct thread *t = thread_current(); // 현재 스레드가 어떤스레드인지 확인.
+    struct thread *t = thread_current(); // 현재 스레드가 어떤스레드인지 확인.
 
-	/* Update statistics. 상태정보들 업데이트*/
-	if (t == idle_thread) //  idle쓰레드면
-		idle_ticks++;	  //  idle쓰레드의 틱을 증가
+    /* Update statistics. 상태정보들 업데이트*/
+    if (t == idle_thread) //  idle쓰레드면
+        idle_ticks++;     //  idle쓰레드의 틱을 증가
 #ifdef USERPROG
-	else if (t->pml4 != NULL)
-		user_ticks++;
+    else if (t->pml4 != NULL)
+        user_ticks++;
 #endif
-	else //
-		kernel_ticks++;
+    else //
+        kernel_ticks++;
 
-	/* Enforce preemption.
-	   선점 실행 */
-	if (++thread_ticks >= TIME_SLICE)
-		intr_yield_on_return();
+    /* Enforce preemption.
+       선점 실행 */
+    if (++thread_ticks >= TIME_SLICE)
+        intr_yield_on_return();
 }
 
 /* Prints thread statistics.
    쓰레드 통계 출력 */
 void thread_print_stats(void)
 {
-	printf("Thread: %lld idle ticks, %lld kernel ticks, %lld user ticks\n",
-		   idle_ticks, kernel_ticks, user_ticks);
+    printf("Thread: %lld idle ticks, %lld kernel ticks, %lld user ticks\n",
+           idle_ticks, kernel_ticks, user_ticks);
 }
 
 /* Creates a new kernel thread named NAME with the given initial
@@ -289,10 +289,10 @@ void thread_print_stats(void)
    thread may run for any amount of time before the new thread is
    scheduled.  Use a semaphore or some other form of
    synchronization if you need to ensure ordering.
-	강탈방식스케쥴링이 호출되면(thread_start()), 반환되기전에 호출하면서 만드는
-	새로운 idle 쓰레드가 스케줄 될 수 있다. 심지어 반환되기도 전에 종료될 수 있다.
-	반대로, 원래스레드는 새 스레드가 예약되기 전에 임의의 시간동안 실행될 수 있습니다.
-	이와같은 순서를 확실하게 하고싶으면 세마포어나 다른 동기화방식을 쓰세요.
+    강탈방식스케쥴링이 호출되면(thread_start()), 반환되기전에 호출하면서 만드는
+    새로운 idle 쓰레드가 스케줄 될 수 있다. 심지어 반환되기도 전에 종료될 수 있다.
+    반대로, 원래스레드는 새 스레드가 예약되기 전에 임의의 시간동안 실행될 수 있습니다.
+    이와같은 순서를 확실하게 하고싶으면 세마포어나 다른 동기화방식을 쓰세요.
    The code provided sets the new thread's 'priority' member to
    PRIORITY, but no actual priority scheduling is implemented.
    Priority scheduling is the goal of Problem 1-3.
@@ -310,55 +310,55 @@ void thread_print_stats(void)
    우선순위 스케줄링은 문제 1-3의 목표입니다.
    */
 tid_t thread_create(const char *name, int priority,
-					thread_func *function, void *aux)
+                    thread_func *function, void *aux)
 {
-	struct thread *t;
-	tid_t tid;
-	enum intr_level old_level;
+    struct thread *t;
+    tid_t tid;
+    enum intr_level old_level;
 
-	ASSERT(function != NULL);
+    ASSERT(function != NULL);
 
-	/* Allocate thread.
-	   쓰레드 할당 */
-	t = palloc_get_page(PAL_ZERO);
-	if (t == NULL)
-		return TID_ERROR;
+    /* Allocate thread.
+       쓰레드 할당 */
+    t = palloc_get_page(PAL_ZERO);
+    if (t == NULL)
+        return TID_ERROR;
 
-	/* Initialize thread.
-	   쓰레드 초기화 */
-	init_thread(t, name, priority);
-	tid = t->tid = allocate_tid();
-	/* Call the kernel_thread if it scheduled.
-	 * Note) rdi is 1st argument, and rsi is 2nd argument.
-	 *
-	 * 스케줄되면 kernel_thread를 호출합니다.
-	 * 참고) rdi는 첫 번째 인수이고, rsi는 두 번째 인수입니다. */
+    /* Initialize thread.
+       쓰레드 초기화 */
+    init_thread(t, name, priority);
+    tid = t->tid = allocate_tid();
+    /* Call the kernel_thread if it scheduled.
+     * Note) rdi is 1st argument, and rsi is 2nd argument.
+     *
+     * 스케줄되면 kernel_thread를 호출합니다.
+     * 참고) rdi는 첫 번째 인수이고, rsi는 두 번째 인수입니다. */
 
-	t->tf.rip = (uintptr_t)kernel_thread;
-	t->tf.R.rdi = (uint64_t)function;
-	t->tf.R.rsi = (uint64_t)aux;
-	t->tf.ds = SEL_KDSEG;
-	t->tf.es = SEL_KDSEG;
-	t->tf.ss = SEL_KDSEG;
-	t->tf.cs = SEL_KCSEG;
-	t->tf.eflags = FLAG_IF;
+    t->tf.rip = (uintptr_t)kernel_thread;
+    t->tf.R.rdi = (uint64_t)function;
+    t->tf.R.rsi = (uint64_t)aux;
+    t->tf.ds = SEL_KDSEG;
+    t->tf.es = SEL_KDSEG;
+    t->tf.ss = SEL_KDSEG;
+    t->tf.cs = SEL_KCSEG;
+    t->tf.eflags = FLAG_IF;
 
-	/* Add to run queue.
-	   실행 큐에 추가 */
+    /* Add to run queue.
+       실행 큐에 추가 */
 
-	list_push_back(&thread_list, &t->th_elem);
+    list_push_back(&thread_list, &t->th_elem);
 
-	thread_unblock(t);
+    thread_unblock(t);
 
-	struct thread *curr = running_thread();
-	int cur_priority = curr->priority;
+    struct thread *curr = running_thread();
+    int cur_priority = curr->priority;
 
-	if (!list_empty(&ready_list) && list_entry(list_front(&ready_list), struct thread, elem)->priority > cur_priority)
-	{
-		thread_yield();
-	}
+    if (!list_empty(&ready_list) && list_entry(list_front(&ready_list), struct thread, elem)->priority > cur_priority)
+    {
+        thread_yield();
+    }
 
-	return tid;
+    return tid;
 }
 
 /* Puts the current thread to sleep.  It will not be scheduled
@@ -371,17 +371,17 @@ tid_t thread_create(const char *name, int priority,
    하는 것이 더 좋은 아이디어이다.*/
 void thread_block(void)
 {
-	ASSERT(!intr_context());				   // 지금 컨텍스트가 외부신호 인터럽트가 아님
-	ASSERT(intr_get_level() == INTR_OFF);	   //  현재 인터럽트 비활성화여야함.
-	thread_current()->status = THREAD_BLOCKED; //  현재스레드의 상태를 스레드블락으로 만듦
-	schedule();
+    ASSERT(!intr_context());                   // 지금 컨텍스트가 외부신호 인터럽트가 아님
+    ASSERT(intr_get_level() == INTR_OFF);      //  현재 인터럽트 비활성화여야함.
+    thread_current()->status = THREAD_BLOCKED; //  현재스레드의 상태를 스레드블락으로 만듦
+    schedule();
 }
 
 /* Transitions a blocked thread T to the ready-to-run state.
    This is an error if T is not blocked.  (Use thread_yield() to
    make the running thread ready.)
-	잠든, 막힌, 블락된 쓰레드 T를 실행준비상태로 변환한다. 쓰레드T가 블락 안되어있으면
-	이거는 에러다. (실행중인 쓰레드가 ready상태로 되게, thread_yield()를 사용하라.)
+    잠든, 막힌, 블락된 쓰레드 T를 실행준비상태로 변환한다. 쓰레드T가 블락 안되어있으면
+    이거는 에러다. (실행중인 쓰레드가 ready상태로 되게, thread_yield()를 사용하라.)
    This function does not preempt the running thread.  This can
    be important: if the caller had disabled interrupts itself,
    it may expect that it can atomically unblock a thread and
@@ -397,37 +397,37 @@ void thread_block(void)
    */
 void thread_unblock(struct thread *t)
 {
-	enum intr_level old_level;
+    enum intr_level old_level;
 
-	ASSERT(is_thread(t));
-	old_level = intr_disable();
-	ASSERT(t->status == THREAD_BLOCKED);
-	// list_push_back(&ready_list, &t->elem);
-	list_insert_ordered(&ready_list, &t->elem, (list_less_func *)priority, NULL);
-	t->status = THREAD_READY;
-	intr_set_level(old_level);
+    ASSERT(is_thread(t));
+    old_level = intr_disable();
+    ASSERT(t->status == THREAD_BLOCKED);
+    // list_push_back(&ready_list, &t->elem);
+    list_insert_ordered(&ready_list, &t->elem, (list_less_func *)priority, NULL);
+    t->status = THREAD_READY;
+    intr_set_level(old_level);
 }
 
 void thread_preempt(void)
 {
-	int curr_prio = thread_current()->priority;
-	if (list_empty(&ready_list))
-		return;
+    int curr_prio = thread_current()->priority;
+    if (list_empty(&ready_list))
+        return;
 
-	/* 	if (curr_prio < list_entry(list_front(&ready_list), struct thread, elem)->priority)
-		{
-			do_schedule(THREAD_READY);
-		} */
-	if (list_entry(list_front(&ready_list), struct thread, elem)->priority > curr_prio)
-	{
-		thread_yield();
-	}
+    /* 	if (curr_prio < list_entry(list_front(&ready_list), struct thread, elem)->priority)
+        {
+            do_schedule(THREAD_READY);
+        } */
+    if (list_entry(list_front(&ready_list), struct thread, elem)->priority > curr_prio)
+    {
+        thread_yield();
+    }
 }
 /* Returns the name of the running thread.
    실행 중인 스레드의 이름을 반환합니다. */
 const char *thread_name(void)
 {
-	return thread_current()->name;
+    return thread_current()->name;
 }
 
 /* Returns the running thread.
@@ -440,67 +440,67 @@ const char *thread_name(void)
 struct thread *
 thread_current(void)
 {
-	struct thread *t = running_thread();
+    struct thread *t = running_thread();
 
-	/* Make sure T is really a thread.
-	   If either of these assertions fire, then your thread may
-	   have overflowed its stack.  Each thread has less than 4 kB
-	   of stack, so a few big automatic arrays or moderate
-	   recursion can cause stack overflow.
+    /* Make sure T is really a thread.
+       If either of these assertions fire, then your thread may
+       have overflowed its stack.  Each thread has less than 4 kB
+       of stack, so a few big automatic arrays or moderate
+       recursion can cause stack overflow.
 
-	   T가 실제로 스레드인지 확인하십시오.
-	   이 assertions 중 하나라도 발생하면 스레드가 스택을 오버플로했을 수 있습니다.
-	   각 스레드는 4 kB 미만의 스택을 가지므로
-	   큰 자동 배열이나 중간 정도의 재귀는 스택 오버플로를 일으킬 수 있습니다. */
-	ASSERT(is_thread(t));
-	ASSERT(t->status == THREAD_RUNNING);
+       T가 실제로 스레드인지 확인하십시오.
+       이 assertions 중 하나라도 발생하면 스레드가 스택을 오버플로했을 수 있습니다.
+       각 스레드는 4 kB 미만의 스택을 가지므로
+       큰 자동 배열이나 중간 정도의 재귀는 스택 오버플로를 일으킬 수 있습니다. */
+    ASSERT(is_thread(t));
+    ASSERT(t->status == THREAD_RUNNING);
 
-	return t;
+    return t;
 }
 
 void thread_sleep(int64_t ticks)
 {
-	struct thread *curr = thread_current();
-	enum intr_level old_level;
+    struct thread *curr = thread_current();
+    enum intr_level old_level;
 
-	old_level = intr_disable();
-	if (curr != idle_thread)
-	{
-		curr->status = THREAD_BLOCKED;
-		curr->wakeup_tick = ticks;
-		list_insert_ordered(&sleep_list, &curr->elem, (list_less_func *)less, NULL);
-	}
-	schedule();
-	intr_set_level(old_level);
+    old_level = intr_disable();
+    if (curr != idle_thread)
+    {
+        curr->status = THREAD_BLOCKED;
+        curr->wakeup_tick = ticks;
+        list_insert_ordered(&sleep_list, &curr->elem, (list_less_func *)less, NULL);
+    }
+    schedule();
+    intr_set_level(old_level);
 }
 
 void thread_wakeup(int64_t ticks)
 {
-	if (list_empty(&sleep_list))
-		return;
+    if (list_empty(&sleep_list))
+        return;
 
-	enum intr_level old_level;
-	struct thread *to_wakeup = list_entry(list_front(&sleep_list), struct thread, elem);
+    enum intr_level old_level;
+    struct thread *to_wakeup = list_entry(list_front(&sleep_list), struct thread, elem);
 
-	old_level = intr_disable();
-	while (to_wakeup->wakeup_tick <= ticks)
-	{
-		list_pop_front(&sleep_list);
-		list_insert_ordered(&ready_list, &to_wakeup->elem, (list_less_func *)priority, NULL);
-		to_wakeup->status = THREAD_READY;
-		if (list_empty(&sleep_list))
-			return;
-		to_wakeup = list_entry(list_front(&sleep_list), struct thread, elem);
-	}
+    old_level = intr_disable();
+    while (to_wakeup->wakeup_tick <= ticks)
+    {
+        list_pop_front(&sleep_list);
+        list_insert_ordered(&ready_list, &to_wakeup->elem, (list_less_func *)priority, NULL);
+        to_wakeup->status = THREAD_READY;
+        if (list_empty(&sleep_list))
+            return;
+        to_wakeup = list_entry(list_front(&sleep_list), struct thread, elem);
+    }
 
-	intr_set_level(old_level);
+    intr_set_level(old_level);
 }
 
 /* Returns the running thread's tid.
    실행 중인 스레드의 tid를 반환합니다. */
 tid_t thread_tid(void)
 {
-	return thread_current()->tid;
+    return thread_current()->tid;
 }
 
 /* Deschedules the current thread and destroys it.  Never
@@ -510,21 +510,21 @@ tid_t thread_tid(void)
    절대 호출자에게 반환되지 않습니다. */
 void thread_exit(void)
 {
-	ASSERT(!intr_context());
+    ASSERT(!intr_context());
 
 #ifdef USERPROG
-	process_exit();
+    process_exit();
 #endif
 
-	/* Just set our status to dying and schedule another process.
-	   We will be destroyed during the call to schedule_tail().
+    /* Just set our status to dying and schedule another process.
+       We will be destroyed during the call to schedule_tail().
 
-	   그저 우리의 상태를 dying으로 설정하고 다른 프로세스를 스케줄합니다.
-	   schedule_tail() 호출 중에 우리는 파괴될 것입니다. */
+       그저 우리의 상태를 dying으로 설정하고 다른 프로세스를 스케줄합니다.
+       schedule_tail() 호출 중에 우리는 파괴될 것입니다. */
 
-	intr_disable();
-	do_schedule(THREAD_DYING);
-	NOT_REACHED();
+    intr_disable();
+    do_schedule(THREAD_DYING);
+    NOT_REACHED();
 }
 
 /* Yields the CPU.  The current thread is not put to sleep and
@@ -534,125 +534,125 @@ void thread_exit(void)
    스케줄러의 변덕에 따라 즉시 다시 예약될 수 있습니다.*/
 void thread_yield(void)
 {
-	struct thread *curr = thread_current(); // 현재 실행중인 스레드
-	enum intr_level old_level;
+    struct thread *curr = thread_current(); // 현재 실행중인 스레드
+    enum intr_level old_level;
 
-	ASSERT(!intr_context());
+    ASSERT(!intr_context());
 
-	old_level = intr_disable();
-	if (curr != idle_thread)
-	{
-		// list_push_back(&ready_list, &curr->elem);
-		list_insert_ordered(&ready_list, &curr->elem, priority, NULL);
-	}
+    old_level = intr_disable();
+    if (curr != idle_thread)
+    {
+        // list_push_back(&ready_list, &curr->elem);
+        list_insert_ordered(&ready_list, &curr->elem, priority, NULL);
+    }
 
-	// curr->nice++;
+    // curr->nice++;
 
-	do_schedule(THREAD_READY);
-	intr_set_level(old_level);
+    do_schedule(THREAD_READY);
+    intr_set_level(old_level);
 }
 
 /* Sets the current thread's priority to NEW_PRIORITY.
    현재 스레드의 우선순위를 NEW_PRIORITY로 설정합니다. */
 void thread_set_priority(int new_priority)
 {
-	struct thread *curr = thread_current();
-	curr->original = curr->priority = new_priority;
-	// if (!list_empty(&curr->donations))
-	// {
-	// 	curr->priority = list_entry(list_front(&curr->donations), struct thread, d_elem)
-	// 						 ->priority;
-	// }
+    struct thread *curr = thread_current();
+    curr->original = curr->priority = new_priority;
+    // if (!list_empty(&curr->donations))
+    // {
+    // 	curr->priority = list_entry(list_front(&curr->donations), struct thread, d_elem)
+    // 						 ->priority;
+    // }
 
-	if (list_empty(&ready_list))
-		return;
+    if (list_empty(&ready_list))
+        return;
 
-	list_sort(&ready_list, priority, NULL);
+    list_sort(&ready_list, priority, NULL);
 
-	struct thread *top_pri_th = list_entry(list_front(&ready_list), struct thread, elem);
-	int top_priority = top_pri_th->priority;
+    struct thread *top_pri_th = list_entry(list_front(&ready_list), struct thread, elem);
+    int top_priority = top_pri_th->priority;
 
-	if (top_priority > curr->priority)
-	{
-		thread_yield();
-	}
+    if (top_priority > curr->priority)
+    {
+        thread_yield();
+    }
 }
 
 /* Returns the current thread's priority.
    현재 스레드의 우선순위를 반환합니다. */
 int thread_get_priority(void)
 {
-	return thread_current()->priority;
+    return thread_current()->priority;
 }
 
 /* Sets the current thread's nice value to NICE.
    현재 스레드의 nice 값을 NICE로 설정합니다. */
 void thread_set_nice(int nice UNUSED)
 {
-	/* TODO: Your implementation goes here */
+    /* TODO: Your implementation goes here */
 }
 
 /* Returns the current thread's nice value.
    현재 스레드의 nice 값을 반환합니다. */
 int thread_get_nice(void)
 {
-	/* TODO: Your implementation goes here */
-	return 0;
+    /* TODO: Your implementation goes here */
+    return 0;
 }
 
 /* Returns 100 times the system load average.
    시스템 로드 평균의 100배를 반환합니다. */
 int thread_get_load_avg(void)
 {
-	/* TODO: Your implementation goes here */
-	return TOINT(MUL(load_avg, TOFIX(100)));
+    /* TODO: Your implementation goes here */
+    return TOINT(MUL(load_avg, TOFIX(100)));
 }
 
 /* Returns 100 times the current thread's recent_cpu value.
    현재 스레드의 recent_cpu 값을 100배한 값을 반환합니다. */
 int thread_get_recent_cpu(void)
 {
-	/* TODO: Your implementation goes here */
-	return 0;
+    /* TODO: Your implementation goes here */
+    return 0;
 }
 
 int calc_all_priority()
 {
-	// while (thread_list) // ready + block + running - idle   th_elem
-	// {
-	// 	th->priority = PRI_MAX - (th->recent_cpu / 4) - (th->nice * 2);
-	// }
+    // while (thread_list) // ready + block + running - idle   th_elem
+    // {
+    // 	th->priority = PRI_MAX - (th->recent_cpu / 4) - (th->nice * 2);
+    // }
 }
 
 /* Calculate one threads' priority. */
 int calc_one_priority(struct thread *t)
 {
-	int recent_cpu = t->recent_cpu;
-	int nice = t->nice;
+    int recent_cpu = t->recent_cpu;
+    int nice = t->nice;
 
-	int priority = PRI_MAX - (((int64_t)recent_cpu) * FIXED / 4) - (nice * 2);
+    int priority = PRI_MAX - (((int64_t)recent_cpu) * FIXED / 4) - (nice * 2);
 
-	return priority;
+    return priority;
 }
 
 void calc_load_avg()
 {
-	ready_threads = list_size(&ready_list); // running, ready 상태의 스레드 갯수
-	if (thread_current() != idle_thread)
-	{
-		ready_threads += 1;
-	}
-	load_avg = MUL((DIV(TOFIX(59), TOFIX(60))), load_avg) + (DIV(TOFIX(1), TOFIX(60))) * ready_threads;
+    ready_threads = list_size(&ready_list); // running, ready 상태의 스레드 갯수
+    if (thread_current() != idle_thread)
+    {
+        ready_threads += 1;
+    }
+    load_avg = MUL((DIV(TOFIX(59), TOFIX(60))), load_avg) + (DIV(TOFIX(1), TOFIX(60))) * ready_threads;
 }
 
 void calc_recent_cpu(struct thread *th)
 {
-	th->recent_cpu = (2 * load_avg) / (2 * load_avg + (1 * FIXED)) * th->recent_cpu + (th->nice * FIXED);
+    th->recent_cpu = (2 * load_avg) / (2 * load_avg + (1 * FIXED)) * th->recent_cpu + (th->nice * FIXED);
 }
 
 void increase_recent_cpu(struct thread *th) // running th -> recent_cpu++  1 tick
 {
-	th->recent_cpu += 1;
+    th->recent_cpu += 1;
 }
 
 /* Idle thread.  Executes when no other thread is ready to run.
@@ -681,41 +681,41 @@ void increase_recent_cpu(struct thread *th) // running th -> recent_cpu++  1 tic
 static void
 idle(void *idle_started_ UNUSED)
 {
-	struct semaphore *idle_started = idle_started_;
+    struct semaphore *idle_started = idle_started_;
 
-	idle_thread = thread_current();
-	sema_up(idle_started);
+    idle_thread = thread_current();
+    sema_up(idle_started);
 
-	for (;;)
-	{
-		/* Let someone else run. */
-		intr_disable();
-		thread_block();
+    for (;;)
+    {
+        /* Let someone else run. */
+        intr_disable();
+        thread_block();
 
-		/* Re-enable interrupts and wait for the next one.
+        /* Re-enable interrupts and wait for the next one.
 
-		   The `sti' instruction disables interrupts until the
-		   completion of the next instruction, so these two
-		   instructions are executed atomically.  This atomicity is
-		   important; otherwise, an interrupt could be handled
-		   between re-enabling interrupts and waiting for the next
-		   one to occur, wasting as much as one clock tick worth of
-		   time.
+           The `sti' instruction disables interrupts until the
+           completion of the next instruction, so these two
+           instructions are executed atomically.  This atomicity is
+           important; otherwise, an interrupt could be handled
+           between re-enabling interrupts and waiting for the next
+           one to occur, wasting as much as one clock tick worth of
+           time.
 
-		   See [IA32-v2a] "HLT", [IA32-v2b] "STI", and [IA32-v3a]
-		   7.11.1 "HLT Instruction".
+           See [IA32-v2a] "HLT", [IA32-v2b] "STI", and [IA32-v3a]
+           7.11.1 "HLT Instruction".
 
-		   다시 인터럽트를 활성화하고 다음 인터럽트를 기다립니다.
+           다시 인터럽트를 활성화하고 다음 인터럽트를 기다립니다.
 
-		   'sti' 명령은 다음 명령의 완료까지 인터럽트를 비활성화하므로
-		   이 두 명령은 원자적으로 실행됩니다. 이 원자성은 중요합니다.
-		   그렇지 않으면 인터럽트가 다시 활성화되고 다음 인터럽트를 기다리는 동안
-		   인터럽트가 처리될 수 있어서 최대 한 클럭 틱의 시간이 낭비될 수 있습니다.
+           'sti' 명령은 다음 명령의 완료까지 인터럽트를 비활성화하므로
+           이 두 명령은 원자적으로 실행됩니다. 이 원자성은 중요합니다.
+           그렇지 않으면 인터럽트가 다시 활성화되고 다음 인터럽트를 기다리는 동안
+           인터럽트가 처리될 수 있어서 최대 한 클럭 틱의 시간이 낭비될 수 있습니다.
 
-		   [IA32-v2a] "HLT", [IA32-v2b] "STI", [IA32-v3a]
-		   7.11.1 "HLT Instruction" 참조 */
-		asm volatile("sti; hlt" : : : "memory");
-	}
+           [IA32-v2a] "HLT", [IA32-v2b] "STI", [IA32-v3a]
+           7.11.1 "HLT Instruction" 참조 */
+        asm volatile("sti; hlt" : : : "memory");
+    }
 }
 
 /* Function used as the basis for a kernel thread.
@@ -723,11 +723,11 @@ idle(void *idle_started_ UNUSED)
 static void
 kernel_thread(thread_func *function, void *aux)
 {
-	ASSERT(function != NULL);
+    ASSERT(function != NULL);
 
-	intr_enable(); /* The scheduler runs with interrupts off. 스케쥴러가 인터럽트 없이 실행됩니다. */
-	function(aux); /* Execute the thread function. 스레드의 기능을 실행시킵니다. */
-	thread_exit(); /* If function() returns, kill the thread. 만약 function()이 반환되면, 스레드를 죽입니다. */
+    intr_enable(); /* The scheduler runs with interrupts off. 스케쥴러가 인터럽트 없이 실행됩니다. */
+    function(aux); /* Execute the thread function. 스레드의 기능을 실행시킵니다. */
+    thread_exit(); /* If function() returns, kill the thread. 만약 function()이 반환되면, 스레드를 죽입니다. */
 }
 
 /* Does basic initialization of T as a blocked thread named NAME.
@@ -735,21 +735,21 @@ kernel_thread(thread_func *function, void *aux)
 static void
 init_thread(struct thread *t, const char *name, int priority)
 {
-	ASSERT(t != NULL);
-	ASSERT(PRI_MIN <= priority && priority <= PRI_MAX);
-	ASSERT(name != NULL);
+    ASSERT(t != NULL);
+    ASSERT(PRI_MIN <= priority && priority <= PRI_MAX);
+    ASSERT(name != NULL);
 
-	memset(t, 0, sizeof *t);
-	t->status = THREAD_BLOCKED;
-	strlcpy(t->name, name, sizeof t->name);
-	t->tf.rsp = (uint64_t)t + PGSIZE - sizeof(void *);
-	t->priority = priority;
-	t->original = priority;
-	// printf("init pri %d  ori %d\n", t->priority, t->original);
-	t->magic = THREAD_MAGIC;
+    memset(t, 0, sizeof *t);
+    t->status = THREAD_BLOCKED;
+    strlcpy(t->name, name, sizeof t->name);
+    t->tf.rsp = (uint64_t)t + PGSIZE - sizeof(void *);
+    t->priority = priority;
+    t->original = priority;
+    // printf("init pri %d  ori %d\n", t->priority, t->original);
+    t->magic = THREAD_MAGIC;
 
-	t->nice = 0;
-	t->recent_cpu = 0;
+    t->nice = 0;
+    t->recent_cpu = 0;
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should
@@ -765,58 +765,58 @@ init_thread(struct thread *t, const char *name, int priority)
 static struct thread *
 next_thread_to_run(void)
 {
-	if (list_empty(&ready_list))
-	{
-		// printf("empty\n");
-		return idle_thread;
-	}
+    if (list_empty(&ready_list))
+    {
+        // printf("empty\n");
+        return idle_thread;
+    }
 
-	else
-	{
-		// list_sort(&ready_list, priority, NULL);
-		// printf("pri:   %d\n", list_entry(list_begin(&ready_list), struct thread, elem)->priority);
-		return list_entry(list_pop_front(&ready_list), struct thread, elem);
-	}
+    else
+    {
+        // list_sort(&ready_list, priority, NULL);
+        // printf("pri:   %d\n", list_entry(list_begin(&ready_list), struct thread, elem)->priority);
+        return list_entry(list_pop_front(&ready_list), struct thread, elem);
+    }
 }
 
 /* Use iretq to launch the thread
    스레드를 시작하기 위해 iretq를 사용합니다. */
 void do_iret(struct intr_frame *tf)
 {
-	__asm __volatile(
-		"movq %0, %%rsp\n"
-		"movq 0(%%rsp),%%r15\n"
-		"movq 8(%%rsp),%%r14\n"
-		"movq 16(%%rsp),%%r13\n"
-		"movq 24(%%rsp),%%r12\n"
-		"movq 32(%%rsp),%%r11\n"
-		"movq 40(%%rsp),%%r10\n"
-		"movq 48(%%rsp),%%r9\n"
-		"movq 56(%%rsp),%%r8\n"
-		"movq 64(%%rsp),%%rsi\n"
-		"movq 72(%%rsp),%%rdi\n"
-		"movq 80(%%rsp),%%rbp\n"
-		"movq 88(%%rsp),%%rdx\n"
-		"movq 96(%%rsp),%%rcx\n"
-		"movq 104(%%rsp),%%rbx\n"
-		"movq 112(%%rsp),%%rax\n"
-		"addq $120,%%rsp\n"
-		"movw 8(%%rsp),%%ds\n"
-		"movw (%%rsp),%%es\n"
-		"addq $32, %%rsp\n"
-		"iretq"
-		: : "g"((uint64_t)tf) : "memory");
+    __asm __volatile(
+        "movq %0, %%rsp\n"
+        "movq 0(%%rsp),%%r15\n"
+        "movq 8(%%rsp),%%r14\n"
+        "movq 16(%%rsp),%%r13\n"
+        "movq 24(%%rsp),%%r12\n"
+        "movq 32(%%rsp),%%r11\n"
+        "movq 40(%%rsp),%%r10\n"
+        "movq 48(%%rsp),%%r9\n"
+        "movq 56(%%rsp),%%r8\n"
+        "movq 64(%%rsp),%%rsi\n"
+        "movq 72(%%rsp),%%rdi\n"
+        "movq 80(%%rsp),%%rbp\n"
+        "movq 88(%%rsp),%%rdx\n"
+        "movq 96(%%rsp),%%rcx\n"
+        "movq 104(%%rsp),%%rbx\n"
+        "movq 112(%%rsp),%%rax\n"
+        "addq $120,%%rsp\n"
+        "movw 8(%%rsp),%%ds\n"
+        "movw (%%rsp),%%es\n"
+        "addq $32, %%rsp\n"
+        "iretq"
+        : : "g"((uint64_t)tf) : "memory");
 }
 
 /* Switching the thread by activating the new thread's page
    tables, and, if the previous thread is dying, destroying it.
-	새 스레드의 페이지테이블을 활성화 하는것으로 쓰레드를 전환한다.
-	이전 쓰레드가 죽어가는 쓰레드면 파괴한다.
+    새 스레드의 페이지테이블을 활성화 하는것으로 쓰레드를 전환한다.
+    이전 쓰레드가 죽어가는 쓰레드면 파괴한다.
    At this function's invocation, we just switched from thread
    PREV, the new thread is already running, and interrupts are
    still disabled.
-	이 함수의 부름(호출?) 시점에, 우리는 이전 쓰레드를 이제막 전환했고, 새 스레드는
-	이미 실행중이며, 인터럽트는 여전히 비활성화 되어있다.
+    이 함수의 부름(호출?) 시점에, 우리는 이전 쓰레드를 이제막 전환했고, 새 스레드는
+    이미 실행중이며, 인터럽트는 여전히 비활성화 되어있다.
    It's not safe to call printf() until the thread switch is
    complete.  In practice that means that printf()s should be
    added at the end of the function.
@@ -827,132 +827,132 @@ void do_iret(struct intr_frame *tf)
 static void
 thread_launch(struct thread *th)
 {
-	uint64_t tf_cur = (uint64_t)&running_thread()->tf;
-	uint64_t tf = (uint64_t)&th->tf;
-	ASSERT(intr_get_level() == INTR_OFF);
+    uint64_t tf_cur = (uint64_t)&running_thread()->tf;
+    uint64_t tf = (uint64_t)&th->tf;
+    ASSERT(intr_get_level() == INTR_OFF);
 
-	/* The main switching logic.
-	메인 문맥전환 로직
-	 * We first restore the whole execution context into the intr_frame
-	 먼저, 전체 실행문맥을 intr_frame에 저장한다.
-	 * and then switching to the next thread by calling do_iret.
-	 그리고 다음 스레드를 do_iret를 호출함으로써 switch한다.
-	 * Note that, we SHOULD NOT use any stack from here
-	 여기서는 문맥전환이 일어나기 까지 어떠한 stack도 써서는 안된다.
-	 * until switching is done. */
-	__asm __volatile(
-		/* Store registers that will be used.
-		 */
+    /* The main switching logic.
+    메인 문맥전환 로직
+     * We first restore the whole execution context into the intr_frame
+     먼저, 전체 실행문맥을 intr_frame에 저장한다.
+     * and then switching to the next thread by calling do_iret.
+     그리고 다음 스레드를 do_iret를 호출함으로써 switch한다.
+     * Note that, we SHOULD NOT use any stack from here
+     여기서는 문맥전환이 일어나기 까지 어떠한 stack도 써서는 안된다.
+     * until switching is done. */
+    __asm __volatile(
+        /* Store registers that will be used.
+         */
 
-		"push %%rax\n"
-		"push %%rbx\n"
-		"push %%rcx\n"
-		/* Fetch input once */
-		"movq %0, %%rax\n"
-		"movq %1, %%rcx\n"
-		"movq %%r15, 0(%%rax)\n"
-		"movq %%r14, 8(%%rax)\n"
-		"movq %%r13, 16(%%rax)\n"
-		"movq %%r12, 24(%%rax)\n"
-		"movq %%r11, 32(%%rax)\n"
-		"movq %%r10, 40(%%rax)\n"
-		"movq %%r9, 48(%%rax)\n"
-		"movq %%r8, 56(%%rax)\n"
-		"movq %%rsi, 64(%%rax)\n"
-		"movq %%rdi, 72(%%rax)\n"
-		"movq %%rbp, 80(%%rax)\n"
-		"movq %%rdx, 88(%%rax)\n"
-		"pop %%rbx\n" // Saved rcx
-		"movq %%rbx, 96(%%rax)\n"
-		"pop %%rbx\n" // Saved rbx
-		"movq %%rbx, 104(%%rax)\n"
-		"pop %%rbx\n" // Saved rax
-		"movq %%rbx, 112(%%rax)\n"
-		"addq $120, %%rax\n"
-		"movw %%es, (%%rax)\n"
-		"movw %%ds, 8(%%rax)\n"
-		"addq $32, %%rax\n"
-		"call __next\n" // read the current rip.
-		"__next:\n"
-		"pop %%rbx\n"
-		"addq $(out_iret -  __next), %%rbx\n"
-		"movq %%rbx, 0(%%rax)\n" // rip
-		"movw %%cs, 8(%%rax)\n"	 // cs
-		"pushfq\n"
-		"popq %%rbx\n"
-		"mov %%rbx, 16(%%rax)\n" // eflags
-		"mov %%rsp, 24(%%rax)\n" // rsp
-		"movw %%ss, 32(%%rax)\n"
-		"mov %%rcx, %%rdi\n"
-		"call do_iret\n"
-		"out_iret:\n"
-		: : "g"(tf_cur), "g"(tf) : "memory");
+        "push %%rax\n"
+        "push %%rbx\n"
+        "push %%rcx\n"
+        /* Fetch input once */
+        "movq %0, %%rax\n"
+        "movq %1, %%rcx\n"
+        "movq %%r15, 0(%%rax)\n"
+        "movq %%r14, 8(%%rax)\n"
+        "movq %%r13, 16(%%rax)\n"
+        "movq %%r12, 24(%%rax)\n"
+        "movq %%r11, 32(%%rax)\n"
+        "movq %%r10, 40(%%rax)\n"
+        "movq %%r9, 48(%%rax)\n"
+        "movq %%r8, 56(%%rax)\n"
+        "movq %%rsi, 64(%%rax)\n"
+        "movq %%rdi, 72(%%rax)\n"
+        "movq %%rbp, 80(%%rax)\n"
+        "movq %%rdx, 88(%%rax)\n"
+        "pop %%rbx\n" // Saved rcx
+        "movq %%rbx, 96(%%rax)\n"
+        "pop %%rbx\n" // Saved rbx
+        "movq %%rbx, 104(%%rax)\n"
+        "pop %%rbx\n" // Saved rax
+        "movq %%rbx, 112(%%rax)\n"
+        "addq $120, %%rax\n"
+        "movw %%es, (%%rax)\n"
+        "movw %%ds, 8(%%rax)\n"
+        "addq $32, %%rax\n"
+        "call __next\n" // read the current rip.
+        "__next:\n"
+        "pop %%rbx\n"
+        "addq $(out_iret -  __next), %%rbx\n"
+        "movq %%rbx, 0(%%rax)\n" // rip
+        "movw %%cs, 8(%%rax)\n"  // cs
+        "pushfq\n"
+        "popq %%rbx\n"
+        "mov %%rbx, 16(%%rax)\n" // eflags
+        "mov %%rsp, 24(%%rax)\n" // rsp
+        "movw %%ss, 32(%%rax)\n"
+        "mov %%rcx, %%rdi\n"
+        "call do_iret\n"
+        "out_iret:\n"
+        : : "g"(tf_cur), "g"(tf) : "memory");
 }
 
 /* Schedules a new process. At entry, interrupts must be off.
-	새로운 프로세스를 스케줄링하라. 처음에 interrupts가 꺼져있어야한다.
+    새로운 프로세스를 스케줄링하라. 처음에 interrupts가 꺼져있어야한다.
  * This function modify current thread's status to status and then
-	이 함수는 현재 스레드의 상태를 다른 상태로 조정하고
+    이 함수는 현재 스레드의 상태를 다른 상태로 조정하고
  * finds another thread to run and switches to it.
-	cpu에 돌릴 다른 스레드를 찾아 그것으로 바꾼다.
+    cpu에 돌릴 다른 스레드를 찾아 그것으로 바꾼다.
  * It's not safe to call printf() in the schedule().
-	schedule내에서 printf를 찍는건 안전치않다. */
+    schedule내에서 printf를 찍는건 안전치않다. */
 static void
 do_schedule(int status)
 {
-	ASSERT(intr_get_level() == INTR_OFF);
-	ASSERT(thread_current()->status == THREAD_RUNNING);
-	while (!list_empty(&destruction_req))
-	{
-		struct thread *victim =
-			list_entry(list_pop_front(&destruction_req), struct thread, elem);
-		palloc_free_page(victim);
-	}
-	thread_current()->status = status;
-	schedule();
+    ASSERT(intr_get_level() == INTR_OFF);
+    ASSERT(thread_current()->status == THREAD_RUNNING);
+    while (!list_empty(&destruction_req))
+    {
+        struct thread *victim =
+            list_entry(list_pop_front(&destruction_req), struct thread, elem);
+        palloc_free_page(victim);
+    }
+    thread_current()->status = status;
+    schedule();
 }
 
 static void
 schedule(void)
 {
-	struct thread *curr = running_thread();
-	struct thread *next = next_thread_to_run();
+    struct thread *curr = running_thread();
+    struct thread *next = next_thread_to_run();
 
-	ASSERT(intr_get_level() == INTR_OFF);
-	ASSERT(curr->status != THREAD_RUNNING);
-	ASSERT(is_thread(next));
-	/* Mark us as running. */
-	next->status = THREAD_RUNNING;
+    ASSERT(intr_get_level() == INTR_OFF);
+    ASSERT(curr->status != THREAD_RUNNING);
+    ASSERT(is_thread(next));
+    /* Mark us as running. */
+    next->status = THREAD_RUNNING;
 
-	/* Start new time slice.
-	새로운 쓰레드틱스??*/
-	thread_ticks = 0;
+    /* Start new time slice.
+    새로운 쓰레드틱스??*/
+    thread_ticks = 0;
 
 #ifdef USERPROG
-	/* Activate the new address space. */
-	process_activate(next);
+    /* Activate the new address space. */
+    process_activate(next);
 #endif
 
-	if (curr != next)
-	{
-		/* If the thread we switched from is dying, destroy its struct
-		   thread. This must happen late so that thread_exit() doesn't
-		   pull out the rug under itself.
-		   We just queuing the page free reqeust here because the page is
-		   currently used by the stack.
-		   The real destruction logic will be called at the beginning of the
-		   schedule(). */
-		if (curr && curr->status == THREAD_DYING && curr != initial_thread)
-		{
-			ASSERT(curr != next);
-			list_push_back(&destruction_req, &curr->elem);
-			list_remove(&curr->th_elem); // DYING 예정인 스레드는 thread_list에서 제거해준다
-		}
+    if (curr != next)
+    {
+        /* If the thread we switched from is dying, destroy its struct
+           thread. This must happen late so that thread_exit() doesn't
+           pull out the rug under itself.
+           We just queuing the page free reqeust here because the page is
+           currently used by the stack.
+           The real destruction logic will be called at the beginning of the
+           schedule(). */
+        if (curr && curr->status == THREAD_DYING && curr != initial_thread)
+        {
+            ASSERT(curr != next);
+            list_push_back(&destruction_req, &curr->elem);
+            list_remove(&curr->th_elem); // DYING 예정인 스레드는 thread_list에서 제거해준다
+        }
 
-		/* Before switching the thread, we first save the information
-		 * of current running. */
-		thread_launch(next);
-	}
+        /* Before switching the thread, we first save the information
+         * of current running. */
+        thread_launch(next);
+    }
 }
 
 /* Returns a tid to use for a new thread.
@@ -961,12 +961,12 @@ schedule(void)
 static tid_t
 allocate_tid(void)
 {
-	static tid_t next_tid = 1; // 정적변수. 증가시키면서 할당할 스레드ID값
-	tid_t tid;
+    static tid_t next_tid = 1; // 정적변수. 증가시키면서 할당할 스레드ID값
+    tid_t tid;
 
-	lock_acquire(&tid_lock); // tid들이 경쟁적으로 가져갈 lock키의 주소를 얻음
-	tid = next_tid++;		 //  tid에 다음tid 할당
-	lock_release(&tid_lock); //
+    lock_acquire(&tid_lock); // tid들이 경쟁적으로 가져갈 lock키의 주소를 얻음
+    tid = next_tid++;        //  tid에 다음tid 할당
+    lock_release(&tid_lock); //
 
-	return tid;
+    return tid;
 }

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -86,6 +86,7 @@ bool thread_mlfqs;
 
 int f = 1 << 14; // p 17 q 14
 static int load_avg;
+static struct list thread_list;
 
 static void kernel_thread(thread_func *, void *aux);
 
@@ -187,6 +188,7 @@ void thread_init(void)
 	lock_init(&tid_lock);
 	list_init(&ready_list);
 	list_init(&sleep_list);
+	list_init(&thread_list);
 	list_init(&destruction_req);
 
 	/* Set up a thread structure for the running thread.
@@ -323,6 +325,8 @@ tid_t thread_create(const char *name, int priority,
 
 	/* Add to run queue.
 	   실행 큐에 추가 */
+
+	list_push_back(&thread_list, &t->th_elem);
 
 	thread_unblock(t);
 
@@ -595,24 +599,21 @@ int thread_get_recent_cpu(void)
 
 int calc_all_priority()
 {
-	while (thread_list) // ready + block + running - idle   th_elem
-	{
-		th->priority = PRI_MAX - (th->recent_cpu / 4) - (th->nice * 2);
-	}
+}
+
+int calc_one_priority()
+{
 }
 
 int calc_load_avg()
 {
-	load_avg = (59 / 60) * load_avg + (1 / 60) * ready_threads; // ready_threads - running, ready 상태의 스레드 갯수
-	list_size(&ready_list) + 1;
+	int ready_threads = list_size(&ready_list) + 1; // running, ready 상태의 스레드 갯수
+	load_avg = ((int64_t)(59 / 60)) * load_avg / f + (1 / 60) * ready_threads;
+	// int64_t 일때 f = 1 << 31 ??
 }
 
 int calc_recent_cpu()
 {
-	while (thread_list)
-	{
-		th->recent_cpu = (2 * load_avg) / (2 * load_avg + 1) * th->recent_cpu + th->nice;
-	}
 }
 
 int increase_cpu() // running th -> recent_cpu++  1 tick
@@ -910,6 +911,7 @@ schedule(void)
 		{
 			ASSERT(curr != next);
 			list_push_back(&destruction_req, &curr->elem);
+			list_remove(&curr->th_elem); // DYING 예정인 스레드는 thread_list에서 제거해준다
 		}
 
 		/* Before switching the thread, we first save the information

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -72,7 +72,7 @@ static long long kernel_ticks; /* 정적변수 ### of timer ticks in kernel thre
 static long long user_ticks;   /* 정적변수 ### of timer ticks in user programs. */
 
 /* Scheduling. */
-#define TIME_SLICE 4          /* 스케줄링을 위한 간격 ### of timer ticks to give each thread. */
+#define TIME_SLICE 4		  /* 스케줄링을 위한 간격 ### of timer ticks to give each thread. */
 static unsigned thread_ticks; /* 마지막 양보 부터의 타이머틱스 ### of timer ticks since last yield. */
 
 /* If false (default), use round-robin scheduler.
@@ -84,9 +84,17 @@ static unsigned thread_ticks; /* 마지막 양보 부터의 타이머틱스 ### 
    커널의 커맨드라인 옵션인 "-o mlfqs"에 의해 조정된다*/
 bool thread_mlfqs;
 
-int f = 1 << 14; // p 17 q 14
+// int f = 1 << 14; // p 17 q 14
 static int load_avg;
 static struct list thread_list;
+
+#define FIXED 1 << 14
+#define ADD(x, y) ((x) + ((y) * FIXED))
+#define SUB(x, y) ((x) - ((y) * FIXED))
+#define MUL(x, y) (((int64_t)x) * (y) / FIXED)
+#define DIV(x, y) (((int64_t)x) * FIXED / (y))
+#define TOINT(x) ((x + FIXED / 2) / FIXED)
+#define TOFIX(x) (x * FIXED)
 
 static void kernel_thread(thread_func *, void *aux);
 
@@ -153,18 +161,18 @@ static uint64_t gdt[3] = {0, 0x00af9a000000ffff, 0x00cf92000000ffff};
 
 bool less(const struct list_elem *a, const struct list_elem *b, void *aux)
 {
-    struct thread *ta = list_entry(a, struct thread, elem);
-    struct thread *tb = list_entry(b, struct thread, elem);
+	struct thread *ta = list_entry(a, struct thread, elem);
+	struct thread *tb = list_entry(b, struct thread, elem);
 
-    return ta->wakeup_tick < tb->wakeup_tick;
+	return ta->wakeup_tick < tb->wakeup_tick;
 }
 
 bool priority(const struct list_elem *a, const struct list_elem *b, void *aux)
 {
-    struct thread *ta = list_entry(a, struct thread, elem);
-    struct thread *tb = list_entry(b, struct thread, elem);
+	struct thread *ta = list_entry(a, struct thread, elem);
+	struct thread *tb = list_entry(b, struct thread, elem);
 
-    return ta->priority > tb->priority;
+	return ta->priority > tb->priority;
 }
 
 void thread_init(void)
@@ -209,52 +217,52 @@ void thread_init(void)
    */
 void thread_start(void)
 {
-    /* Create the idle thread.
-       유휴 스레드를 생성합니다. */
-    struct semaphore idle_started;
-    sema_init(&idle_started, 0);
-    thread_create("idle", PRI_MIN, idle, &idle_started);
+	/* Create the idle thread.
+	   유휴 스레드를 생성합니다. */
+	struct semaphore idle_started;
+	sema_init(&idle_started, 0);
+	thread_create("idle", PRI_MIN, idle, &idle_started);
 
-    /* Start preemptive thread scheduling.
-       선점형 스레드 스케줄링을 시작합니다. */
-    intr_enable();
+	/* Start preemptive thread scheduling.
+	   선점형 스레드 스케줄링을 시작합니다. */
+	intr_enable();
 
-    /* Wait for the idle thread to initialize idle_thread.
-       유휴 스레드가 idle_thread를 초기화 하기를 기다립니다. */
-    sema_down(&idle_started);
+	/* Wait for the idle thread to initialize idle_thread.
+	   유휴 스레드가 idle_thread를 초기화 하기를 기다립니다. */
+	sema_down(&idle_started);
 }
 
 /* Called by the timer interrupt handler at each timer tick.
    Thus, this function runs in an external interrupt context.
-    매 타이머의 틱마다, 타이머 인터럽트 핸들러에 의해 불려진다.
+	매 타이머의 틱마다, 타이머 인터럽트 핸들러에 의해 불려진다.
    그래서, 이 함수는 external문맥(외부신호인터럽트)에서 실행된다.
    */
 void thread_tick(void)
 {
-    struct thread *t = thread_current(); // 현재 스레드가 어떤스레드인지 확인.
+	struct thread *t = thread_current(); // 현재 스레드가 어떤스레드인지 확인.
 
-    /* Update statistics. 상태정보들 업데이트*/
-    if (t == idle_thread) //  idle쓰레드면
-        idle_ticks++;     //  idle쓰레드의 틱을 증가
+	/* Update statistics. 상태정보들 업데이트*/
+	if (t == idle_thread) //  idle쓰레드면
+		idle_ticks++;	  //  idle쓰레드의 틱을 증가
 #ifdef USERPROG
-    else if (t->pml4 != NULL)
-        user_ticks++;
+	else if (t->pml4 != NULL)
+		user_ticks++;
 #endif
-    else //
-        kernel_ticks++;
+	else //
+		kernel_ticks++;
 
-    /* Enforce preemption.
-       선점 실행 */
-    if (++thread_ticks >= TIME_SLICE)
-        intr_yield_on_return();
+	/* Enforce preemption.
+	   선점 실행 */
+	if (++thread_ticks >= TIME_SLICE)
+		intr_yield_on_return();
 }
 
 /* Prints thread statistics.
    쓰레드 통계 출력 */
 void thread_print_stats(void)
 {
-    printf("Thread: %lld idle ticks, %lld kernel ticks, %lld user ticks\n",
-           idle_ticks, kernel_ticks, user_ticks);
+	printf("Thread: %lld idle ticks, %lld kernel ticks, %lld user ticks\n",
+		   idle_ticks, kernel_ticks, user_ticks);
 }
 
 /* Creates a new kernel thread named NAME with the given initial
@@ -269,10 +277,10 @@ void thread_print_stats(void)
    thread may run for any amount of time before the new thread is
    scheduled.  Use a semaphore or some other form of
    synchronization if you need to ensure ordering.
-    강탈방식스케쥴링이 호출되면(thread_start()), 반환되기전에 호출하면서 만드는
-    새로운 idle 쓰레드가 스케줄 될 수 있다. 심지어 반환되기도 전에 종료될 수 있다.
-    반대로, 원래스레드는 새 스레드가 예약되기 전에 임의의 시간동안 실행될 수 있습니다.
-    이와같은 순서를 확실하게 하고싶으면 세마포어나 다른 동기화방식을 쓰세요.
+	강탈방식스케쥴링이 호출되면(thread_start()), 반환되기전에 호출하면서 만드는
+	새로운 idle 쓰레드가 스케줄 될 수 있다. 심지어 반환되기도 전에 종료될 수 있다.
+	반대로, 원래스레드는 새 스레드가 예약되기 전에 임의의 시간동안 실행될 수 있습니다.
+	이와같은 순서를 확실하게 하고싶으면 세마포어나 다른 동기화방식을 쓰세요.
    The code provided sets the new thread's 'priority' member to
    PRIORITY, but no actual priority scheduling is implemented.
    Priority scheduling is the goal of Problem 1-3.
@@ -290,56 +298,55 @@ void thread_print_stats(void)
    우선순위 스케줄링은 문제 1-3의 목표입니다.
    */
 tid_t thread_create(const char *name, int priority,
-                    thread_func *function, void *aux)
+					thread_func *function, void *aux)
 {
-    struct thread *t;
-    tid_t tid;
-    enum intr_level old_level;
+	struct thread *t;
+	tid_t tid;
+	enum intr_level old_level;
 
-    ASSERT(function != NULL);
+	ASSERT(function != NULL);
 
-    /* Allocate thread.
-       쓰레드 할당 */
-    t = palloc_get_page(PAL_ZERO);
-    if (t == NULL)
-        return TID_ERROR;
+	/* Allocate thread.
+	   쓰레드 할당 */
+	t = palloc_get_page(PAL_ZERO);
+	if (t == NULL)
+		return TID_ERROR;
 
-    /* Initialize thread.
-       쓰레드 초기화 */
-    init_thread(t, name, priority);
-    tid = t->tid = allocate_tid();
-    /* Call the kernel_thread if it scheduled.
-     * Note) rdi is 1st argument, and rsi is 2nd argument.
-     *
-     * 스케줄되면 kernel_thread를 호출합니다.
-     * 참고) rdi는 첫 번째 인수이고, rsi는 두 번째 인수입니다. */
+	/* Initialize thread.
+	   쓰레드 초기화 */
+	init_thread(t, name, priority);
+	tid = t->tid = allocate_tid();
+	/* Call the kernel_thread if it scheduled.
+	 * Note) rdi is 1st argument, and rsi is 2nd argument.
+	 *
+	 * 스케줄되면 kernel_thread를 호출합니다.
+	 * 참고) rdi는 첫 번째 인수이고, rsi는 두 번째 인수입니다. */
 
-    t->tf.rip = (uintptr_t)kernel_thread;
-    t->tf.R.rdi = (uint64_t)function;
-    t->tf.R.rsi = (uint64_t)aux;
-    t->tf.ds = SEL_KDSEG;
-    t->tf.es = SEL_KDSEG;
-    t->tf.ss = SEL_KDSEG;
-    t->tf.cs = SEL_KCSEG;
-    t->tf.eflags = FLAG_IF;
+	t->tf.rip = (uintptr_t)kernel_thread;
+	t->tf.R.rdi = (uint64_t)function;
+	t->tf.R.rsi = (uint64_t)aux;
+	t->tf.ds = SEL_KDSEG;
+	t->tf.es = SEL_KDSEG;
+	t->tf.ss = SEL_KDSEG;
+	t->tf.cs = SEL_KCSEG;
+	t->tf.eflags = FLAG_IF;
 
-    /* Add to run queue.
-       실행 큐에 추가 */
+	/* Add to run queue.
+	   실행 큐에 추가 */
 
-    thread_unblock(t);
 	list_push_back(&thread_list, &t->th_elem);
 
 	thread_unblock(t);
 
-    struct thread *curr = running_thread();
-    int cur_priority = curr->priority;
+	struct thread *curr = running_thread();
+	int cur_priority = curr->priority;
 
-    if (!list_empty(&ready_list) && list_entry(list_front(&ready_list), struct thread, elem)->priority > cur_priority)
-    {
-        thread_yield();
-    }
+	if (!list_empty(&ready_list) && list_entry(list_front(&ready_list), struct thread, elem)->priority > cur_priority)
+	{
+		thread_yield();
+	}
 
-    return tid;
+	return tid;
 }
 
 /* Puts the current thread to sleep.  It will not be scheduled
@@ -352,17 +359,17 @@ tid_t thread_create(const char *name, int priority,
    하는 것이 더 좋은 아이디어이다.*/
 void thread_block(void)
 {
-    ASSERT(!intr_context());                   // 지금 컨텍스트가 외부신호 인터럽트가 아님
-    ASSERT(intr_get_level() == INTR_OFF);      //  현재 인터럽트 비활성화여야함.
-    thread_current()->status = THREAD_BLOCKED; //  현재스레드의 상태를 스레드블락으로 만듦
-    schedule();
+	ASSERT(!intr_context());				   // 지금 컨텍스트가 외부신호 인터럽트가 아님
+	ASSERT(intr_get_level() == INTR_OFF);	   //  현재 인터럽트 비활성화여야함.
+	thread_current()->status = THREAD_BLOCKED; //  현재스레드의 상태를 스레드블락으로 만듦
+	schedule();
 }
 
 /* Transitions a blocked thread T to the ready-to-run state.
    This is an error if T is not blocked.  (Use thread_yield() to
    make the running thread ready.)
-    잠든, 막힌, 블락된 쓰레드 T를 실행준비상태로 변환한다. 쓰레드T가 블락 안되어있으면
-    이거는 에러다. (실행중인 쓰레드가 ready상태로 되게, thread_yield()를 사용하라.)
+	잠든, 막힌, 블락된 쓰레드 T를 실행준비상태로 변환한다. 쓰레드T가 블락 안되어있으면
+	이거는 에러다. (실행중인 쓰레드가 ready상태로 되게, thread_yield()를 사용하라.)
    This function does not preempt the running thread.  This can
    be important: if the caller had disabled interrupts itself,
    it may expect that it can atomically unblock a thread and
@@ -378,37 +385,37 @@ void thread_block(void)
    */
 void thread_unblock(struct thread *t)
 {
-    enum intr_level old_level;
+	enum intr_level old_level;
 
-    ASSERT(is_thread(t));
-    old_level = intr_disable();
-    ASSERT(t->status == THREAD_BLOCKED);
-    // list_push_back(&ready_list, &t->elem);
-    list_insert_ordered(&ready_list, &t->elem, (list_less_func *)priority, NULL);
-    t->status = THREAD_READY;
-    intr_set_level(old_level);
+	ASSERT(is_thread(t));
+	old_level = intr_disable();
+	ASSERT(t->status == THREAD_BLOCKED);
+	// list_push_back(&ready_list, &t->elem);
+	list_insert_ordered(&ready_list, &t->elem, (list_less_func *)priority, NULL);
+	t->status = THREAD_READY;
+	intr_set_level(old_level);
 }
 
 void thread_preempt(void)
 {
-    int curr_prio = thread_current()->priority;
-    if (list_empty(&ready_list))
-        return;
+	int curr_prio = thread_current()->priority;
+	if (list_empty(&ready_list))
+		return;
 
-    /* 	if (curr_prio < list_entry(list_front(&ready_list), struct thread, elem)->priority)
-        {
-            do_schedule(THREAD_READY);
-        } */
-    if (list_entry(list_front(&ready_list), struct thread, elem)->priority > curr_prio)
-    {
-        thread_yield();
-    }
+	/* 	if (curr_prio < list_entry(list_front(&ready_list), struct thread, elem)->priority)
+		{
+			do_schedule(THREAD_READY);
+		} */
+	if (list_entry(list_front(&ready_list), struct thread, elem)->priority > curr_prio)
+	{
+		thread_yield();
+	}
 }
 /* Returns the name of the running thread.
    실행 중인 스레드의 이름을 반환합니다. */
 const char *thread_name(void)
 {
-    return thread_current()->name;
+	return thread_current()->name;
 }
 
 /* Returns the running thread.
@@ -421,67 +428,67 @@ const char *thread_name(void)
 struct thread *
 thread_current(void)
 {
-    struct thread *t = running_thread();
+	struct thread *t = running_thread();
 
-    /* Make sure T is really a thread.
-       If either of these assertions fire, then your thread may
-       have overflowed its stack.  Each thread has less than 4 kB
-       of stack, so a few big automatic arrays or moderate
-       recursion can cause stack overflow.
+	/* Make sure T is really a thread.
+	   If either of these assertions fire, then your thread may
+	   have overflowed its stack.  Each thread has less than 4 kB
+	   of stack, so a few big automatic arrays or moderate
+	   recursion can cause stack overflow.
 
-       T가 실제로 스레드인지 확인하십시오.
-       이 assertions 중 하나라도 발생하면 스레드가 스택을 오버플로했을 수 있습니다.
-       각 스레드는 4 kB 미만의 스택을 가지므로
-       큰 자동 배열이나 중간 정도의 재귀는 스택 오버플로를 일으킬 수 있습니다. */
-    ASSERT(is_thread(t));
-    ASSERT(t->status == THREAD_RUNNING);
+	   T가 실제로 스레드인지 확인하십시오.
+	   이 assertions 중 하나라도 발생하면 스레드가 스택을 오버플로했을 수 있습니다.
+	   각 스레드는 4 kB 미만의 스택을 가지므로
+	   큰 자동 배열이나 중간 정도의 재귀는 스택 오버플로를 일으킬 수 있습니다. */
+	ASSERT(is_thread(t));
+	ASSERT(t->status == THREAD_RUNNING);
 
-    return t;
+	return t;
 }
 
 void thread_sleep(int64_t ticks)
 {
-    struct thread *curr = thread_current();
-    enum intr_level old_level;
+	struct thread *curr = thread_current();
+	enum intr_level old_level;
 
-    old_level = intr_disable();
-    if (curr != idle_thread)
-    {
-        curr->status = THREAD_BLOCKED;
-        curr->wakeup_tick = ticks;
-        list_insert_ordered(&sleep_list, &curr->elem, (list_less_func *)less, NULL);
-    }
-    schedule();
-    intr_set_level(old_level);
+	old_level = intr_disable();
+	if (curr != idle_thread)
+	{
+		curr->status = THREAD_BLOCKED;
+		curr->wakeup_tick = ticks;
+		list_insert_ordered(&sleep_list, &curr->elem, (list_less_func *)less, NULL);
+	}
+	schedule();
+	intr_set_level(old_level);
 }
 
 void thread_wakeup(int64_t ticks)
 {
-    if (list_empty(&sleep_list))
-        return;
+	if (list_empty(&sleep_list))
+		return;
 
-    enum intr_level old_level;
-    struct thread *to_wakeup = list_entry(list_front(&sleep_list), struct thread, elem);
+	enum intr_level old_level;
+	struct thread *to_wakeup = list_entry(list_front(&sleep_list), struct thread, elem);
 
-    old_level = intr_disable();
-    while (to_wakeup->wakeup_tick <= ticks)
-    {
-        list_pop_front(&sleep_list);
-        list_insert_ordered(&ready_list, &to_wakeup->elem, (list_less_func *)priority, NULL);
-        to_wakeup->status = THREAD_READY;
-        if (list_empty(&sleep_list))
-            return;
-        to_wakeup = list_entry(list_front(&sleep_list), struct thread, elem);
-    }
+	old_level = intr_disable();
+	while (to_wakeup->wakeup_tick <= ticks)
+	{
+		list_pop_front(&sleep_list);
+		list_insert_ordered(&ready_list, &to_wakeup->elem, (list_less_func *)priority, NULL);
+		to_wakeup->status = THREAD_READY;
+		if (list_empty(&sleep_list))
+			return;
+		to_wakeup = list_entry(list_front(&sleep_list), struct thread, elem);
+	}
 
-    intr_set_level(old_level);
+	intr_set_level(old_level);
 }
 
 /* Returns the running thread's tid.
    실행 중인 스레드의 tid를 반환합니다. */
 tid_t thread_tid(void)
 {
-    return thread_current()->tid;
+	return thread_current()->tid;
 }
 
 /* Deschedules the current thread and destroys it.  Never
@@ -491,21 +498,21 @@ tid_t thread_tid(void)
    절대 호출자에게 반환되지 않습니다. */
 void thread_exit(void)
 {
-    ASSERT(!intr_context());
+	ASSERT(!intr_context());
 
 #ifdef USERPROG
-    process_exit();
+	process_exit();
 #endif
 
-    /* Just set our status to dying and schedule another process.
-       We will be destroyed during the call to schedule_tail().
+	/* Just set our status to dying and schedule another process.
+	   We will be destroyed during the call to schedule_tail().
 
-       그저 우리의 상태를 dying으로 설정하고 다른 프로세스를 스케줄합니다.
-       schedule_tail() 호출 중에 우리는 파괴될 것입니다. */
+	   그저 우리의 상태를 dying으로 설정하고 다른 프로세스를 스케줄합니다.
+	   schedule_tail() 호출 중에 우리는 파괴될 것입니다. */
 
-    intr_disable();
-    do_schedule(THREAD_DYING);
-    NOT_REACHED();
+	intr_disable();
+	do_schedule(THREAD_DYING);
+	NOT_REACHED();
 }
 
 /* Yields the CPU.  The current thread is not put to sleep and
@@ -515,127 +522,135 @@ void thread_exit(void)
    스케줄러의 변덕에 따라 즉시 다시 예약될 수 있습니다.*/
 void thread_yield(void)
 {
-    struct thread *curr = thread_current(); // 현재 실행중인 스레드
-    enum intr_level old_level;
+	struct thread *curr = thread_current(); // 현재 실행중인 스레드
+	enum intr_level old_level;
 
-    ASSERT(!intr_context());
+	ASSERT(!intr_context());
 
-    old_level = intr_disable();
-    if (curr != idle_thread)
-    {
-        // list_push_back(&ready_list, &curr->elem);
-        list_insert_ordered(&ready_list, &curr->elem, priority, NULL);
-    }
+	old_level = intr_disable();
+	if (curr != idle_thread)
+	{
+		// list_push_back(&ready_list, &curr->elem);
+		list_insert_ordered(&ready_list, &curr->elem, priority, NULL);
+	}
 
-    // curr->nice++;
+	// curr->nice++;
 
-    do_schedule(THREAD_READY);
-    intr_set_level(old_level);
+	do_schedule(THREAD_READY);
+	intr_set_level(old_level);
 }
 
 /* Sets the current thread's priority to NEW_PRIORITY.
    현재 스레드의 우선순위를 NEW_PRIORITY로 설정합니다. */
 void thread_set_priority(int new_priority)
 {
-    struct thread *curr = thread_current();
-    curr->original = curr->priority = new_priority;
-    // if (!list_empty(&curr->donations))
-    // {
-    // 	curr->priority = list_entry(list_front(&curr->donations), struct thread, d_elem)
-    // 						 ->priority;
-    // }
+	struct thread *curr = thread_current();
+	curr->original = curr->priority = new_priority;
+	// if (!list_empty(&curr->donations))
+	// {
+	// 	curr->priority = list_entry(list_front(&curr->donations), struct thread, d_elem)
+	// 						 ->priority;
+	// }
 
-    if (list_empty(&ready_list))
-        return;
+	if (list_empty(&ready_list))
+		return;
 
-    list_sort(&ready_list, priority, NULL);
+	list_sort(&ready_list, priority, NULL);
 
-    struct thread *top_pri_th = list_entry(list_front(&ready_list), struct thread, elem);
-    int top_priority = top_pri_th->priority;
+	struct thread *top_pri_th = list_entry(list_front(&ready_list), struct thread, elem);
+	int top_priority = top_pri_th->priority;
 
-    if (top_priority > curr->priority)
-    {
-        thread_yield();
-    }
+	if (top_priority > curr->priority)
+	{
+		thread_yield();
+	}
 }
 
 /* Returns the current thread's priority.
    현재 스레드의 우선순위를 반환합니다. */
 int thread_get_priority(void)
 {
-    return thread_current()->priority;
+	return thread_current()->priority;
 }
 
 /* Sets the current thread's nice value to NICE.
    현재 스레드의 nice 값을 NICE로 설정합니다. */
 void thread_set_nice(int nice UNUSED)
 {
-    /* TODO: Your implementation goes here */
+	/* TODO: Your implementation goes here */
 }
 
 /* Returns the current thread's nice value.
    현재 스레드의 nice 값을 반환합니다. */
 int thread_get_nice(void)
 {
-    /* TODO: Your implementation goes here */
-    return 0;
+	/* TODO: Your implementation goes here */
+	return 0;
 }
 
 /* Returns 100 times the system load average.
    시스템 로드 평균의 100배를 반환합니다. */
 int thread_get_load_avg(void)
 {
-    /* TODO: Your implementation goes here */
+	/* TODO: Your implementation goes here */
 
-    return 0;
+	return load_avg * 100;
 }
 
 /* Returns 100 times the current thread's recent_cpu value.
    현재 스레드의 recent_cpu 값을 100배한 값을 반환합니다. */
 int thread_get_recent_cpu(void)
 {
-    /* TODO: Your implementation goes here */
-    return 0;
+	/* TODO: Your implementation goes here */
+	return 0;
 }
 
 int calc_all_priority()
 {
-    while (thread_list) // ready + block + running - idle   th_elem
-    {
-        th->priority = PRI_MAX - (th->recent_cpu / 4) - (th->nice * 2);
-    }
+	// while (thread_list) // ready + block + running - idle   th_elem
+	// {
+	// 	th->priority = PRI_MAX - (th->recent_cpu / 4) - (th->nice * 2);
+	// }
 }
 
 /* Calculate one threads' priority. */
 int calc_one_priority(struct thread *t)
 {
-    double recent_cpu = t->recent_cpu;
-    int nice = t->nice;
+	int recent_cpu = t->recent_cpu;
+	int nice = t->nice;
 
-    int priority = PRI_MAX - (((int64_t)recent_cpu) * f / 4) - (nice * 2);
+	int priority = PRI_MAX - (((int64_t)recent_cpu) * FIXED / 4) - (nice * 2);
 
-    return priority;
+	return priority;
 }
 
-int calc_load_avg()
+void calc_load_avg()
 {
 	int ready_threads = list_size(&ready_list); // running, ready 상태의 스레드 갯수
 	if (thread_current()->name != "idle")
 	{
 		ready_threads += 1;
 	}
-	load_avg = ((int64_t)(59 / 60)) * load_avg / f + (1 / 60) * ready_threads;
-	// int64_t 일때 f = 1 << 31 ??
+	// load_avg = ((int64_t)(((int64_t)(59 * FIXED) * FIXED) / (60 * FIXED))) * (load_avg * FIXED) / FIXED + ((int64_t)(((int64_t)(1 * FIXED)) * FIXED / (60 * FIXED))) * (ready_threads * FIXED) / FIXED;
+	int cur_avg;
+	int next_avg;
+	// cur_avg = load_avg;
+	// next_avg = ((((int64_t)((59 / 60) * FIXED)) * cur_avg) / FIXED + FIXED / 2) / FIXED + ((((int64_t)((1 / 60) * FIXED) + FIXED / 2) / FIXED) * ready_threads);
+	//  next_avg = ((((((59 * f) / 60)) * cur_avg) + (((1 * f) / 60)) * ready_threads) + f / 2) / f;
+	// load_avg = next_avg;
+	// load_avg = MUL((TOFIX(59) / 60), load_avg) + MUL((TOFIX(1) / 60), ready_threads);
+	load_avg = MUL((DIV(TOFIX(59), TOFIX(60))), load_avg) + DIV(TOFIX(1), TOFIX(60)) * ready_threads;
+	//  load_avg = (((((int64_t)((59 * FIXED) / 60)) * (load_avg * FIXED)) / FIXED + ((1 * FIXED) / 60) * ready_threads) + FIXED / 2) / FIXED;
 }
 
-int calc_recent_cpu(struct thread *th)
+void calc_recent_cpu(struct thread *th)
 {
-	th->recent_cpu = (2 * load_avg) / (2 * load_avg + 1) * th->recent_cpu + th->nice;
+	th->recent_cpu = (2 * load_avg) / (2 * load_avg + (1 * FIXED)) * th->recent_cpu + (th->nice * FIXED);
 }
 
-int increase_recent_cpu(struct thread *th) // running th -> recent_cpu++  1 tick
+void increase_recent_cpu(struct thread *th) // running th -> recent_cpu++  1 tick
 {
-	th->recent_cpu++;
+	th->recent_cpu += 1;
 }
 
 /* Idle thread.  Executes when no other thread is ready to run.
@@ -664,41 +679,41 @@ int increase_recent_cpu(struct thread *th) // running th -> recent_cpu++  1 tick
 static void
 idle(void *idle_started_ UNUSED)
 {
-    struct semaphore *idle_started = idle_started_;
+	struct semaphore *idle_started = idle_started_;
 
-    idle_thread = thread_current();
-    sema_up(idle_started);
+	idle_thread = thread_current();
+	sema_up(idle_started);
 
-    for (;;)
-    {
-        /* Let someone else run. */
-        intr_disable();
-        thread_block();
+	for (;;)
+	{
+		/* Let someone else run. */
+		intr_disable();
+		thread_block();
 
-        /* Re-enable interrupts and wait for the next one.
+		/* Re-enable interrupts and wait for the next one.
 
-           The `sti' instruction disables interrupts until the
-           completion of the next instruction, so these two
-           instructions are executed atomically.  This atomicity is
-           important; otherwise, an interrupt could be handled
-           between re-enabling interrupts and waiting for the next
-           one to occur, wasting as much as one clock tick worth of
-           time.
+		   The `sti' instruction disables interrupts until the
+		   completion of the next instruction, so these two
+		   instructions are executed atomically.  This atomicity is
+		   important; otherwise, an interrupt could be handled
+		   between re-enabling interrupts and waiting for the next
+		   one to occur, wasting as much as one clock tick worth of
+		   time.
 
-           See [IA32-v2a] "HLT", [IA32-v2b] "STI", and [IA32-v3a]
-           7.11.1 "HLT Instruction".
+		   See [IA32-v2a] "HLT", [IA32-v2b] "STI", and [IA32-v3a]
+		   7.11.1 "HLT Instruction".
 
-           다시 인터럽트를 활성화하고 다음 인터럽트를 기다립니다.
+		   다시 인터럽트를 활성화하고 다음 인터럽트를 기다립니다.
 
-           'sti' 명령은 다음 명령의 완료까지 인터럽트를 비활성화하므로
-           이 두 명령은 원자적으로 실행됩니다. 이 원자성은 중요합니다.
-           그렇지 않으면 인터럽트가 다시 활성화되고 다음 인터럽트를 기다리는 동안
-           인터럽트가 처리될 수 있어서 최대 한 클럭 틱의 시간이 낭비될 수 있습니다.
+		   'sti' 명령은 다음 명령의 완료까지 인터럽트를 비활성화하므로
+		   이 두 명령은 원자적으로 실행됩니다. 이 원자성은 중요합니다.
+		   그렇지 않으면 인터럽트가 다시 활성화되고 다음 인터럽트를 기다리는 동안
+		   인터럽트가 처리될 수 있어서 최대 한 클럭 틱의 시간이 낭비될 수 있습니다.
 
-           [IA32-v2a] "HLT", [IA32-v2b] "STI", [IA32-v3a]
-           7.11.1 "HLT Instruction" 참조 */
-        asm volatile("sti; hlt" : : : "memory");
-    }
+		   [IA32-v2a] "HLT", [IA32-v2b] "STI", [IA32-v3a]
+		   7.11.1 "HLT Instruction" 참조 */
+		asm volatile("sti; hlt" : : : "memory");
+	}
 }
 
 /* Function used as the basis for a kernel thread.
@@ -706,11 +721,11 @@ idle(void *idle_started_ UNUSED)
 static void
 kernel_thread(thread_func *function, void *aux)
 {
-    ASSERT(function != NULL);
+	ASSERT(function != NULL);
 
-    intr_enable(); /* The scheduler runs with interrupts off. 스케쥴러가 인터럽트 없이 실행됩니다. */
-    function(aux); /* Execute the thread function. 스레드의 기능을 실행시킵니다. */
-    thread_exit(); /* If function() returns, kill the thread. 만약 function()이 반환되면, 스레드를 죽입니다. */
+	intr_enable(); /* The scheduler runs with interrupts off. 스케쥴러가 인터럽트 없이 실행됩니다. */
+	function(aux); /* Execute the thread function. 스레드의 기능을 실행시킵니다. */
+	thread_exit(); /* If function() returns, kill the thread. 만약 function()이 반환되면, 스레드를 죽입니다. */
 }
 
 /* Does basic initialization of T as a blocked thread named NAME.
@@ -718,21 +733,21 @@ kernel_thread(thread_func *function, void *aux)
 static void
 init_thread(struct thread *t, const char *name, int priority)
 {
-    ASSERT(t != NULL);
-    ASSERT(PRI_MIN <= priority && priority <= PRI_MAX);
-    ASSERT(name != NULL);
+	ASSERT(t != NULL);
+	ASSERT(PRI_MIN <= priority && priority <= PRI_MAX);
+	ASSERT(name != NULL);
 
-    memset(t, 0, sizeof *t);
-    t->status = THREAD_BLOCKED;
-    strlcpy(t->name, name, sizeof t->name);
-    t->tf.rsp = (uint64_t)t + PGSIZE - sizeof(void *);
-    t->priority = priority;
-    t->original = priority;
-    // printf("init pri %d  ori %d\n", t->priority, t->original);
-    t->magic = THREAD_MAGIC;
+	memset(t, 0, sizeof *t);
+	t->status = THREAD_BLOCKED;
+	strlcpy(t->name, name, sizeof t->name);
+	t->tf.rsp = (uint64_t)t + PGSIZE - sizeof(void *);
+	t->priority = priority;
+	t->original = priority;
+	// printf("init pri %d  ori %d\n", t->priority, t->original);
+	t->magic = THREAD_MAGIC;
 
-    t->nice = 0;
-    t->recent_cpu = 0;
+	t->nice = 0;
+	t->recent_cpu = 0;
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should
@@ -748,58 +763,58 @@ init_thread(struct thread *t, const char *name, int priority)
 static struct thread *
 next_thread_to_run(void)
 {
-    if (list_empty(&ready_list))
-    {
-        // printf("empty\n");
-        return idle_thread;
-    }
+	if (list_empty(&ready_list))
+	{
+		// printf("empty\n");
+		return idle_thread;
+	}
 
-    else
-    {
-        // list_sort(&ready_list, priority, NULL);
-        // printf("pri:   %d\n", list_entry(list_begin(&ready_list), struct thread, elem)->priority);
-        return list_entry(list_pop_front(&ready_list), struct thread, elem);
-    }
+	else
+	{
+		// list_sort(&ready_list, priority, NULL);
+		// printf("pri:   %d\n", list_entry(list_begin(&ready_list), struct thread, elem)->priority);
+		return list_entry(list_pop_front(&ready_list), struct thread, elem);
+	}
 }
 
 /* Use iretq to launch the thread
    스레드를 시작하기 위해 iretq를 사용합니다. */
 void do_iret(struct intr_frame *tf)
 {
-    __asm __volatile(
-        "movq %0, %%rsp\n"
-        "movq 0(%%rsp),%%r15\n"
-        "movq 8(%%rsp),%%r14\n"
-        "movq 16(%%rsp),%%r13\n"
-        "movq 24(%%rsp),%%r12\n"
-        "movq 32(%%rsp),%%r11\n"
-        "movq 40(%%rsp),%%r10\n"
-        "movq 48(%%rsp),%%r9\n"
-        "movq 56(%%rsp),%%r8\n"
-        "movq 64(%%rsp),%%rsi\n"
-        "movq 72(%%rsp),%%rdi\n"
-        "movq 80(%%rsp),%%rbp\n"
-        "movq 88(%%rsp),%%rdx\n"
-        "movq 96(%%rsp),%%rcx\n"
-        "movq 104(%%rsp),%%rbx\n"
-        "movq 112(%%rsp),%%rax\n"
-        "addq $120,%%rsp\n"
-        "movw 8(%%rsp),%%ds\n"
-        "movw (%%rsp),%%es\n"
-        "addq $32, %%rsp\n"
-        "iretq"
-        : : "g"((uint64_t)tf) : "memory");
+	__asm __volatile(
+		"movq %0, %%rsp\n"
+		"movq 0(%%rsp),%%r15\n"
+		"movq 8(%%rsp),%%r14\n"
+		"movq 16(%%rsp),%%r13\n"
+		"movq 24(%%rsp),%%r12\n"
+		"movq 32(%%rsp),%%r11\n"
+		"movq 40(%%rsp),%%r10\n"
+		"movq 48(%%rsp),%%r9\n"
+		"movq 56(%%rsp),%%r8\n"
+		"movq 64(%%rsp),%%rsi\n"
+		"movq 72(%%rsp),%%rdi\n"
+		"movq 80(%%rsp),%%rbp\n"
+		"movq 88(%%rsp),%%rdx\n"
+		"movq 96(%%rsp),%%rcx\n"
+		"movq 104(%%rsp),%%rbx\n"
+		"movq 112(%%rsp),%%rax\n"
+		"addq $120,%%rsp\n"
+		"movw 8(%%rsp),%%ds\n"
+		"movw (%%rsp),%%es\n"
+		"addq $32, %%rsp\n"
+		"iretq"
+		: : "g"((uint64_t)tf) : "memory");
 }
 
 /* Switching the thread by activating the new thread's page
    tables, and, if the previous thread is dying, destroying it.
-    새 스레드의 페이지테이블을 활성화 하는것으로 쓰레드를 전환한다.
-    이전 쓰레드가 죽어가는 쓰레드면 파괴한다.
+	새 스레드의 페이지테이블을 활성화 하는것으로 쓰레드를 전환한다.
+	이전 쓰레드가 죽어가는 쓰레드면 파괴한다.
    At this function's invocation, we just switched from thread
    PREV, the new thread is already running, and interrupts are
    still disabled.
-    이 함수의 부름(호출?) 시점에, 우리는 이전 쓰레드를 이제막 전환했고, 새 스레드는
-    이미 실행중이며, 인터럽트는 여전히 비활성화 되어있다.
+	이 함수의 부름(호출?) 시점에, 우리는 이전 쓰레드를 이제막 전환했고, 새 스레드는
+	이미 실행중이며, 인터럽트는 여전히 비활성화 되어있다.
    It's not safe to call printf() until the thread switch is
    complete.  In practice that means that printf()s should be
    added at the end of the function.
@@ -810,110 +825,110 @@ void do_iret(struct intr_frame *tf)
 static void
 thread_launch(struct thread *th)
 {
-    uint64_t tf_cur = (uint64_t)&running_thread()->tf;
-    uint64_t tf = (uint64_t)&th->tf;
-    ASSERT(intr_get_level() == INTR_OFF);
+	uint64_t tf_cur = (uint64_t)&running_thread()->tf;
+	uint64_t tf = (uint64_t)&th->tf;
+	ASSERT(intr_get_level() == INTR_OFF);
 
-    /* The main switching logic.
-    메인 문맥전환 로직
-     * We first restore the whole execution context into the intr_frame
-     먼저, 전체 실행문맥을 intr_frame에 저장한다.
-     * and then switching to the next thread by calling do_iret.
-     그리고 다음 스레드를 do_iret를 호출함으로써 switch한다.
-     * Note that, we SHOULD NOT use any stack from here
-     여기서는 문맥전환이 일어나기 까지 어떠한 stack도 써서는 안된다.
-     * until switching is done. */
-    __asm __volatile(
-        /* Store registers that will be used.
-         */
+	/* The main switching logic.
+	메인 문맥전환 로직
+	 * We first restore the whole execution context into the intr_frame
+	 먼저, 전체 실행문맥을 intr_frame에 저장한다.
+	 * and then switching to the next thread by calling do_iret.
+	 그리고 다음 스레드를 do_iret를 호출함으로써 switch한다.
+	 * Note that, we SHOULD NOT use any stack from here
+	 여기서는 문맥전환이 일어나기 까지 어떠한 stack도 써서는 안된다.
+	 * until switching is done. */
+	__asm __volatile(
+		/* Store registers that will be used.
+		 */
 
-        "push %%rax\n"
-        "push %%rbx\n"
-        "push %%rcx\n"
-        /* Fetch input once */
-        "movq %0, %%rax\n"
-        "movq %1, %%rcx\n"
-        "movq %%r15, 0(%%rax)\n"
-        "movq %%r14, 8(%%rax)\n"
-        "movq %%r13, 16(%%rax)\n"
-        "movq %%r12, 24(%%rax)\n"
-        "movq %%r11, 32(%%rax)\n"
-        "movq %%r10, 40(%%rax)\n"
-        "movq %%r9, 48(%%rax)\n"
-        "movq %%r8, 56(%%rax)\n"
-        "movq %%rsi, 64(%%rax)\n"
-        "movq %%rdi, 72(%%rax)\n"
-        "movq %%rbp, 80(%%rax)\n"
-        "movq %%rdx, 88(%%rax)\n"
-        "pop %%rbx\n" // Saved rcx
-        "movq %%rbx, 96(%%rax)\n"
-        "pop %%rbx\n" // Saved rbx
-        "movq %%rbx, 104(%%rax)\n"
-        "pop %%rbx\n" // Saved rax
-        "movq %%rbx, 112(%%rax)\n"
-        "addq $120, %%rax\n"
-        "movw %%es, (%%rax)\n"
-        "movw %%ds, 8(%%rax)\n"
-        "addq $32, %%rax\n"
-        "call __next\n" // read the current rip.
-        "__next:\n"
-        "pop %%rbx\n"
-        "addq $(out_iret -  __next), %%rbx\n"
-        "movq %%rbx, 0(%%rax)\n" // rip
-        "movw %%cs, 8(%%rax)\n"  // cs
-        "pushfq\n"
-        "popq %%rbx\n"
-        "mov %%rbx, 16(%%rax)\n" // eflags
-        "mov %%rsp, 24(%%rax)\n" // rsp
-        "movw %%ss, 32(%%rax)\n"
-        "mov %%rcx, %%rdi\n"
-        "call do_iret\n"
-        "out_iret:\n"
-        : : "g"(tf_cur), "g"(tf) : "memory");
+		"push %%rax\n"
+		"push %%rbx\n"
+		"push %%rcx\n"
+		/* Fetch input once */
+		"movq %0, %%rax\n"
+		"movq %1, %%rcx\n"
+		"movq %%r15, 0(%%rax)\n"
+		"movq %%r14, 8(%%rax)\n"
+		"movq %%r13, 16(%%rax)\n"
+		"movq %%r12, 24(%%rax)\n"
+		"movq %%r11, 32(%%rax)\n"
+		"movq %%r10, 40(%%rax)\n"
+		"movq %%r9, 48(%%rax)\n"
+		"movq %%r8, 56(%%rax)\n"
+		"movq %%rsi, 64(%%rax)\n"
+		"movq %%rdi, 72(%%rax)\n"
+		"movq %%rbp, 80(%%rax)\n"
+		"movq %%rdx, 88(%%rax)\n"
+		"pop %%rbx\n" // Saved rcx
+		"movq %%rbx, 96(%%rax)\n"
+		"pop %%rbx\n" // Saved rbx
+		"movq %%rbx, 104(%%rax)\n"
+		"pop %%rbx\n" // Saved rax
+		"movq %%rbx, 112(%%rax)\n"
+		"addq $120, %%rax\n"
+		"movw %%es, (%%rax)\n"
+		"movw %%ds, 8(%%rax)\n"
+		"addq $32, %%rax\n"
+		"call __next\n" // read the current rip.
+		"__next:\n"
+		"pop %%rbx\n"
+		"addq $(out_iret -  __next), %%rbx\n"
+		"movq %%rbx, 0(%%rax)\n" // rip
+		"movw %%cs, 8(%%rax)\n"	 // cs
+		"pushfq\n"
+		"popq %%rbx\n"
+		"mov %%rbx, 16(%%rax)\n" // eflags
+		"mov %%rsp, 24(%%rax)\n" // rsp
+		"movw %%ss, 32(%%rax)\n"
+		"mov %%rcx, %%rdi\n"
+		"call do_iret\n"
+		"out_iret:\n"
+		: : "g"(tf_cur), "g"(tf) : "memory");
 }
 
 /* Schedules a new process. At entry, interrupts must be off.
-    새로운 프로세스를 스케줄링하라. 처음에 interrupts가 꺼져있어야한다.
+	새로운 프로세스를 스케줄링하라. 처음에 interrupts가 꺼져있어야한다.
  * This function modify current thread's status to status and then
-    이 함수는 현재 스레드의 상태를 다른 상태로 조정하고
+	이 함수는 현재 스레드의 상태를 다른 상태로 조정하고
  * finds another thread to run and switches to it.
-    cpu에 돌릴 다른 스레드를 찾아 그것으로 바꾼다.
+	cpu에 돌릴 다른 스레드를 찾아 그것으로 바꾼다.
  * It's not safe to call printf() in the schedule().
-    schedule내에서 printf를 찍는건 안전치않다. */
+	schedule내에서 printf를 찍는건 안전치않다. */
 static void
 do_schedule(int status)
 {
-    ASSERT(intr_get_level() == INTR_OFF);
-    ASSERT(thread_current()->status == THREAD_RUNNING);
-    while (!list_empty(&destruction_req))
-    {
-        struct thread *victim =
-            list_entry(list_pop_front(&destruction_req), struct thread, elem);
-        palloc_free_page(victim);
-    }
-    thread_current()->status = status;
-    schedule();
+	ASSERT(intr_get_level() == INTR_OFF);
+	ASSERT(thread_current()->status == THREAD_RUNNING);
+	while (!list_empty(&destruction_req))
+	{
+		struct thread *victim =
+			list_entry(list_pop_front(&destruction_req), struct thread, elem);
+		palloc_free_page(victim);
+	}
+	thread_current()->status = status;
+	schedule();
 }
 
 static void
 schedule(void)
 {
-    struct thread *curr = running_thread();
-    struct thread *next = next_thread_to_run();
+	struct thread *curr = running_thread();
+	struct thread *next = next_thread_to_run();
 
-    ASSERT(intr_get_level() == INTR_OFF);
-    ASSERT(curr->status != THREAD_RUNNING);
-    ASSERT(is_thread(next));
-    /* Mark us as running. */
-    next->status = THREAD_RUNNING;
+	ASSERT(intr_get_level() == INTR_OFF);
+	ASSERT(curr->status != THREAD_RUNNING);
+	ASSERT(is_thread(next));
+	/* Mark us as running. */
+	next->status = THREAD_RUNNING;
 
-    /* Start new time slice.
-    새로운 쓰레드틱스??*/
-    thread_ticks = 0;
+	/* Start new time slice.
+	새로운 쓰레드틱스??*/
+	thread_ticks = 0;
 
 #ifdef USERPROG
-    /* Activate the new address space. */
-    process_activate(next);
+	/* Activate the new address space. */
+	process_activate(next);
 #endif
 
 	if (curr != next)
@@ -944,12 +959,12 @@ schedule(void)
 static tid_t
 allocate_tid(void)
 {
-    static tid_t next_tid = 1; // 정적변수. 증가시키면서 할당할 스레드ID값
-    tid_t tid;
+	static tid_t next_tid = 1; // 정적변수. 증가시키면서 할당할 스레드ID값
+	tid_t tid;
 
-    lock_acquire(&tid_lock); // tid들이 경쟁적으로 가져갈 lock키의 주소를 얻음
-    tid = next_tid++;        //  tid에 다음tid 할당
-    lock_release(&tid_lock); //
+	lock_acquire(&tid_lock); // tid들이 경쟁적으로 가져갈 lock키의 주소를 얻음
+	tid = next_tid++;		 //  tid에 다음tid 할당
+	lock_release(&tid_lock); //
 
-    return tid;
+	return tid;
 }

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -607,7 +607,11 @@ int calc_one_priority()
 
 int calc_load_avg()
 {
-	int ready_threads = list_size(&ready_list) + 1; // running, ready 상태의 스레드 갯수
+	int ready_threads = list_size(&ready_list); // running, ready 상태의 스레드 갯수
+	if (thread_current()->name != "idle")
+	{
+		ready_threads += 1;
+	}
 	load_avg = ((int64_t)(59 / 60)) * load_avg / f + (1 / 60) * ready_threads;
 	// int64_t 일때 f = 1 << 31 ??
 }

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -163,14 +163,6 @@ bool priority(const struct list_elem *a, const struct list_elem *b, void *aux)
 	return ta->priority > tb->priority;
 }
 
-bool d_elem_priority(const struct list_elem *a, const struct list_elem *b, void *aux)
-{
-	struct thread *ta = list_entry(a, struct thread, d_elem);
-	struct thread *tb = list_entry(b, struct thread, d_elem);
-
-	return ta->priority > tb->priority;
-}
-
 void thread_init(void)
 {
 	ASSERT(intr_get_level() == INTR_OFF);
@@ -331,7 +323,6 @@ tid_t thread_create(const char *name, int priority,
 
 	struct thread *curr = running_thread();
 	int cur_priority = curr->priority;
-	// printf("tid : %d  T: %d\n", curr->priority, t->priority);
 
 	if (!list_empty(&ready_list) && list_entry(list_front(&ready_list), struct thread, elem)->priority > cur_priority)
 	{
@@ -536,11 +527,11 @@ void thread_set_priority(int new_priority)
 {
 	struct thread *curr = thread_current();
 	curr->original = curr->priority = new_priority;
-	if (!list_empty(&curr->donations))
-	{
-		curr->priority = list_entry(list_front(&curr->donations), struct thread, d_elem)
-							 ->priority;
-	}
+	// if (!list_empty(&curr->donations))
+	// {
+	// 	curr->priority = list_entry(list_front(&curr->donations), struct thread, d_elem)
+	// 						 ->priority;
+	// }
 
 	if (list_empty(&ready_list))
 		return;
@@ -687,7 +678,6 @@ init_thread(struct thread *t, const char *name, int priority)
 	t->original = priority;
 	// printf("init pri %d  ori %d\n", t->priority, t->original);
 	t->magic = THREAD_MAGIC;
-	list_init(&t->donations);
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -607,16 +607,14 @@ int calc_load_avg()
 	list_size(&ready_list) + 1;
 }
 
-int calc_recent_cpu()
+int calc_recent_cpu(struct thread *th)
 {
-	while (thread_list)
-	{
-		th->recent_cpu = (2 * load_avg) / (2 * load_avg + 1) * th->recent_cpu + th->nice;
-	}
+	th->recent_cpu = (2 * load_avg) / (2 * load_avg + 1) * th->recent_cpu + th->nice;
 }
 
-int increase_cpu() // running th -> recent_cpu++  1 tick
+int increase_recent_cpu(struct thread *th) // running th -> recent_cpu++  1 tick
 {
+	th->recent_cpu++;
 }
 
 /* Idle thread.  Executes when no other thread is ready to run.

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -72,7 +72,7 @@ static long long kernel_ticks; /* 정적변수 ### of timer ticks in kernel thre
 static long long user_ticks;   /* 정적변수 ### of timer ticks in user programs. */
 
 /* Scheduling. */
-#define TIME_SLICE 4		  /* 스케줄링을 위한 간격 ### of timer ticks to give each thread. */
+#define TIME_SLICE 4          /* 스케줄링을 위한 간격 ### of timer ticks to give each thread. */
 static unsigned thread_ticks; /* 마지막 양보 부터의 타이머틱스 ### of timer ticks since last yield. */
 
 /* If false (default), use round-robin scheduler.
@@ -152,51 +152,51 @@ static uint64_t gdt[3] = {0, 0x00af9a000000ffff, 0x00cf92000000ffff};
 
 bool less(const struct list_elem *a, const struct list_elem *b, void *aux)
 {
-	struct thread *ta = list_entry(a, struct thread, elem);
-	struct thread *tb = list_entry(b, struct thread, elem);
+    struct thread *ta = list_entry(a, struct thread, elem);
+    struct thread *tb = list_entry(b, struct thread, elem);
 
-	return ta->wakeup_tick < tb->wakeup_tick;
+    return ta->wakeup_tick < tb->wakeup_tick;
 }
 
 bool priority(const struct list_elem *a, const struct list_elem *b, void *aux)
 {
-	struct thread *ta = list_entry(a, struct thread, elem);
-	struct thread *tb = list_entry(b, struct thread, elem);
+    struct thread *ta = list_entry(a, struct thread, elem);
+    struct thread *tb = list_entry(b, struct thread, elem);
 
-	return ta->priority > tb->priority;
+    return ta->priority > tb->priority;
 }
 
 void thread_init(void)
 {
-	ASSERT(intr_get_level() == INTR_OFF);
+    ASSERT(intr_get_level() == INTR_OFF);
 
-	/* Reload the temporal gdt for the kernel
-	 * This gdt does not include the user context.
-	 * The kernel will rebuild the gdt with user context, in gdt_init ().
-	 *
-	 * 커널을 위해 임시 gdt를 다시 로드합니다.
-	 * 이 gdt에는 사용자 컨텍스트가 포함되어 있지 않습니다.
-	 * 커널은 사용자 컨텍스트가 포함된 gdt를 gdt_init()에서 다시 만들 것입니다. */
-	struct desc_ptr gdt_ds = {
-		.size = sizeof(gdt) - 1,
-		.address = (uint64_t)gdt};
-	lgdt(&gdt_ds);
+    /* Reload the temporal gdt for the kernel
+     * This gdt does not include the user context.
+     * The kernel will rebuild the gdt with user context, in gdt_init ().
+     *
+     * 커널을 위해 임시 gdt를 다시 로드합니다.
+     * 이 gdt에는 사용자 컨텍스트가 포함되어 있지 않습니다.
+     * 커널은 사용자 컨텍스트가 포함된 gdt를 gdt_init()에서 다시 만들 것입니다. */
+    struct desc_ptr gdt_ds = {
+        .size = sizeof(gdt) - 1,
+        .address = (uint64_t)gdt};
+    lgdt(&gdt_ds);
 
-	/* Init the global thread context
-	   전역 스레드 컨텍스트 초기화 */
-	lock_init(&tid_lock);
-	list_init(&ready_list);
-	list_init(&sleep_list);
-	list_init(&destruction_req);
+    /* Init the global thread context
+       전역 스레드 컨텍스트 초기화 */
+    lock_init(&tid_lock);
+    list_init(&ready_list);
+    list_init(&sleep_list);
+    list_init(&destruction_req);
 
-	/* Set up a thread structure for the running thread.
-	   실행중인 쓰레드를 위한 쓰레드 구조를 설정 */
-	initial_thread = running_thread();
-	init_thread(initial_thread, "main", PRI_DEFAULT);
-	initial_thread->status = THREAD_RUNNING;
-	initial_thread->tid = allocate_tid();
+    /* Set up a thread structure for the running thread.
+       실행중인 쓰레드를 위한 쓰레드 구조를 설정 */
+    initial_thread = running_thread();
+    init_thread(initial_thread, "main", PRI_DEFAULT);
+    initial_thread->status = THREAD_RUNNING;
+    initial_thread->tid = allocate_tid();
 
-	load_avg = 0;
+    load_avg = 0;
 }
 
 /* Starts preemptive thread scheduling by enabling interrupts.
@@ -207,52 +207,52 @@ void thread_init(void)
    */
 void thread_start(void)
 {
-	/* Create the idle thread.
-	   유휴 스레드를 생성합니다. */
-	struct semaphore idle_started;
-	sema_init(&idle_started, 0);
-	thread_create("idle", PRI_MIN, idle, &idle_started);
+    /* Create the idle thread.
+       유휴 스레드를 생성합니다. */
+    struct semaphore idle_started;
+    sema_init(&idle_started, 0);
+    thread_create("idle", PRI_MIN, idle, &idle_started);
 
-	/* Start preemptive thread scheduling.
-	   선점형 스레드 스케줄링을 시작합니다. */
-	intr_enable();
+    /* Start preemptive thread scheduling.
+       선점형 스레드 스케줄링을 시작합니다. */
+    intr_enable();
 
-	/* Wait for the idle thread to initialize idle_thread.
-	   유휴 스레드가 idle_thread를 초기화 하기를 기다립니다. */
-	sema_down(&idle_started);
+    /* Wait for the idle thread to initialize idle_thread.
+       유휴 스레드가 idle_thread를 초기화 하기를 기다립니다. */
+    sema_down(&idle_started);
 }
 
 /* Called by the timer interrupt handler at each timer tick.
    Thus, this function runs in an external interrupt context.
-	매 타이머의 틱마다, 타이머 인터럽트 핸들러에 의해 불려진다.
+    매 타이머의 틱마다, 타이머 인터럽트 핸들러에 의해 불려진다.
    그래서, 이 함수는 external문맥(외부신호인터럽트)에서 실행된다.
    */
 void thread_tick(void)
 {
-	struct thread *t = thread_current(); // 현재 스레드가 어떤스레드인지 확인.
+    struct thread *t = thread_current(); // 현재 스레드가 어떤스레드인지 확인.
 
-	/* Update statistics. 상태정보들 업데이트*/
-	if (t == idle_thread) //  idle쓰레드면
-		idle_ticks++;	  //  idle쓰레드의 틱을 증가
+    /* Update statistics. 상태정보들 업데이트*/
+    if (t == idle_thread) //  idle쓰레드면
+        idle_ticks++;     //  idle쓰레드의 틱을 증가
 #ifdef USERPROG
-	else if (t->pml4 != NULL)
-		user_ticks++;
+    else if (t->pml4 != NULL)
+        user_ticks++;
 #endif
-	else //
-		kernel_ticks++;
+    else //
+        kernel_ticks++;
 
-	/* Enforce preemption.
-	   선점 실행 */
-	if (++thread_ticks >= TIME_SLICE)
-		intr_yield_on_return();
+    /* Enforce preemption.
+       선점 실행 */
+    if (++thread_ticks >= TIME_SLICE)
+        intr_yield_on_return();
 }
 
 /* Prints thread statistics.
    쓰레드 통계 출력 */
 void thread_print_stats(void)
 {
-	printf("Thread: %lld idle ticks, %lld kernel ticks, %lld user ticks\n",
-		   idle_ticks, kernel_ticks, user_ticks);
+    printf("Thread: %lld idle ticks, %lld kernel ticks, %lld user ticks\n",
+           idle_ticks, kernel_ticks, user_ticks);
 }
 
 /* Creates a new kernel thread named NAME with the given initial
@@ -267,10 +267,10 @@ void thread_print_stats(void)
    thread may run for any amount of time before the new thread is
    scheduled.  Use a semaphore or some other form of
    synchronization if you need to ensure ordering.
-	강탈방식스케쥴링이 호출되면(thread_start()), 반환되기전에 호출하면서 만드는
-	새로운 idle 쓰레드가 스케줄 될 수 있다. 심지어 반환되기도 전에 종료될 수 있다.
-	반대로, 원래스레드는 새 스레드가 예약되기 전에 임의의 시간동안 실행될 수 있습니다.
-	이와같은 순서를 확실하게 하고싶으면 세마포어나 다른 동기화방식을 쓰세요.
+    강탈방식스케쥴링이 호출되면(thread_start()), 반환되기전에 호출하면서 만드는
+    새로운 idle 쓰레드가 스케줄 될 수 있다. 심지어 반환되기도 전에 종료될 수 있다.
+    반대로, 원래스레드는 새 스레드가 예약되기 전에 임의의 시간동안 실행될 수 있습니다.
+    이와같은 순서를 확실하게 하고싶으면 세마포어나 다른 동기화방식을 쓰세요.
    The code provided sets the new thread's 'priority' member to
    PRIORITY, but no actual priority scheduling is implemented.
    Priority scheduling is the goal of Problem 1-3.
@@ -288,53 +288,53 @@ void thread_print_stats(void)
    우선순위 스케줄링은 문제 1-3의 목표입니다.
    */
 tid_t thread_create(const char *name, int priority,
-					thread_func *function, void *aux)
+                    thread_func *function, void *aux)
 {
-	struct thread *t;
-	tid_t tid;
-	enum intr_level old_level;
+    struct thread *t;
+    tid_t tid;
+    enum intr_level old_level;
 
-	ASSERT(function != NULL);
+    ASSERT(function != NULL);
 
-	/* Allocate thread.
-	   쓰레드 할당 */
-	t = palloc_get_page(PAL_ZERO);
-	if (t == NULL)
-		return TID_ERROR;
+    /* Allocate thread.
+       쓰레드 할당 */
+    t = palloc_get_page(PAL_ZERO);
+    if (t == NULL)
+        return TID_ERROR;
 
-	/* Initialize thread.
-	   쓰레드 초기화 */
-	init_thread(t, name, priority);
-	tid = t->tid = allocate_tid();
-	/* Call the kernel_thread if it scheduled.
-	 * Note) rdi is 1st argument, and rsi is 2nd argument.
-	 *
-	 * 스케줄되면 kernel_thread를 호출합니다.
-	 * 참고) rdi는 첫 번째 인수이고, rsi는 두 번째 인수입니다. */
+    /* Initialize thread.
+       쓰레드 초기화 */
+    init_thread(t, name, priority);
+    tid = t->tid = allocate_tid();
+    /* Call the kernel_thread if it scheduled.
+     * Note) rdi is 1st argument, and rsi is 2nd argument.
+     *
+     * 스케줄되면 kernel_thread를 호출합니다.
+     * 참고) rdi는 첫 번째 인수이고, rsi는 두 번째 인수입니다. */
 
-	t->tf.rip = (uintptr_t)kernel_thread;
-	t->tf.R.rdi = (uint64_t)function;
-	t->tf.R.rsi = (uint64_t)aux;
-	t->tf.ds = SEL_KDSEG;
-	t->tf.es = SEL_KDSEG;
-	t->tf.ss = SEL_KDSEG;
-	t->tf.cs = SEL_KCSEG;
-	t->tf.eflags = FLAG_IF;
+    t->tf.rip = (uintptr_t)kernel_thread;
+    t->tf.R.rdi = (uint64_t)function;
+    t->tf.R.rsi = (uint64_t)aux;
+    t->tf.ds = SEL_KDSEG;
+    t->tf.es = SEL_KDSEG;
+    t->tf.ss = SEL_KDSEG;
+    t->tf.cs = SEL_KCSEG;
+    t->tf.eflags = FLAG_IF;
 
-	/* Add to run queue.
-	   실행 큐에 추가 */
+    /* Add to run queue.
+       실행 큐에 추가 */
 
-	thread_unblock(t);
+    thread_unblock(t);
 
-	struct thread *curr = running_thread();
-	int cur_priority = curr->priority;
+    struct thread *curr = running_thread();
+    int cur_priority = curr->priority;
 
-	if (!list_empty(&ready_list) && list_entry(list_front(&ready_list), struct thread, elem)->priority > cur_priority)
-	{
-		thread_yield();
-	}
+    if (!list_empty(&ready_list) && list_entry(list_front(&ready_list), struct thread, elem)->priority > cur_priority)
+    {
+        thread_yield();
+    }
 
-	return tid;
+    return tid;
 }
 
 /* Puts the current thread to sleep.  It will not be scheduled
@@ -347,17 +347,17 @@ tid_t thread_create(const char *name, int priority,
    하는 것이 더 좋은 아이디어이다.*/
 void thread_block(void)
 {
-	ASSERT(!intr_context());				   // 지금 컨텍스트가 외부신호 인터럽트가 아님
-	ASSERT(intr_get_level() == INTR_OFF);	   //  현재 인터럽트 비활성화여야함.
-	thread_current()->status = THREAD_BLOCKED; //  현재스레드의 상태를 스레드블락으로 만듦
-	schedule();
+    ASSERT(!intr_context());                   // 지금 컨텍스트가 외부신호 인터럽트가 아님
+    ASSERT(intr_get_level() == INTR_OFF);      //  현재 인터럽트 비활성화여야함.
+    thread_current()->status = THREAD_BLOCKED; //  현재스레드의 상태를 스레드블락으로 만듦
+    schedule();
 }
 
 /* Transitions a blocked thread T to the ready-to-run state.
    This is an error if T is not blocked.  (Use thread_yield() to
    make the running thread ready.)
-	잠든, 막힌, 블락된 쓰레드 T를 실행준비상태로 변환한다. 쓰레드T가 블락 안되어있으면
-	이거는 에러다. (실행중인 쓰레드가 ready상태로 되게, thread_yield()를 사용하라.)
+    잠든, 막힌, 블락된 쓰레드 T를 실행준비상태로 변환한다. 쓰레드T가 블락 안되어있으면
+    이거는 에러다. (실행중인 쓰레드가 ready상태로 되게, thread_yield()를 사용하라.)
    This function does not preempt the running thread.  This can
    be important: if the caller had disabled interrupts itself,
    it may expect that it can atomically unblock a thread and
@@ -373,37 +373,37 @@ void thread_block(void)
    */
 void thread_unblock(struct thread *t)
 {
-	enum intr_level old_level;
+    enum intr_level old_level;
 
-	ASSERT(is_thread(t));
-	old_level = intr_disable();
-	ASSERT(t->status == THREAD_BLOCKED);
-	// list_push_back(&ready_list, &t->elem);
-	list_insert_ordered(&ready_list, &t->elem, (list_less_func *)priority, NULL);
-	t->status = THREAD_READY;
-	intr_set_level(old_level);
+    ASSERT(is_thread(t));
+    old_level = intr_disable();
+    ASSERT(t->status == THREAD_BLOCKED);
+    // list_push_back(&ready_list, &t->elem);
+    list_insert_ordered(&ready_list, &t->elem, (list_less_func *)priority, NULL);
+    t->status = THREAD_READY;
+    intr_set_level(old_level);
 }
 
 void thread_preempt(void)
 {
-	int curr_prio = thread_current()->priority;
-	if (list_empty(&ready_list))
-		return;
+    int curr_prio = thread_current()->priority;
+    if (list_empty(&ready_list))
+        return;
 
-	/* 	if (curr_prio < list_entry(list_front(&ready_list), struct thread, elem)->priority)
-		{
-			do_schedule(THREAD_READY);
-		} */
-	if (list_entry(list_front(&ready_list), struct thread, elem)->priority > curr_prio)
-	{
-		thread_yield();
-	}
+    /* 	if (curr_prio < list_entry(list_front(&ready_list), struct thread, elem)->priority)
+        {
+            do_schedule(THREAD_READY);
+        } */
+    if (list_entry(list_front(&ready_list), struct thread, elem)->priority > curr_prio)
+    {
+        thread_yield();
+    }
 }
 /* Returns the name of the running thread.
    실행 중인 스레드의 이름을 반환합니다. */
 const char *thread_name(void)
 {
-	return thread_current()->name;
+    return thread_current()->name;
 }
 
 /* Returns the running thread.
@@ -416,67 +416,67 @@ const char *thread_name(void)
 struct thread *
 thread_current(void)
 {
-	struct thread *t = running_thread();
+    struct thread *t = running_thread();
 
-	/* Make sure T is really a thread.
-	   If either of these assertions fire, then your thread may
-	   have overflowed its stack.  Each thread has less than 4 kB
-	   of stack, so a few big automatic arrays or moderate
-	   recursion can cause stack overflow.
+    /* Make sure T is really a thread.
+       If either of these assertions fire, then your thread may
+       have overflowed its stack.  Each thread has less than 4 kB
+       of stack, so a few big automatic arrays or moderate
+       recursion can cause stack overflow.
 
-	   T가 실제로 스레드인지 확인하십시오.
-	   이 assertions 중 하나라도 발생하면 스레드가 스택을 오버플로했을 수 있습니다.
-	   각 스레드는 4 kB 미만의 스택을 가지므로
-	   큰 자동 배열이나 중간 정도의 재귀는 스택 오버플로를 일으킬 수 있습니다. */
-	ASSERT(is_thread(t));
-	ASSERT(t->status == THREAD_RUNNING);
+       T가 실제로 스레드인지 확인하십시오.
+       이 assertions 중 하나라도 발생하면 스레드가 스택을 오버플로했을 수 있습니다.
+       각 스레드는 4 kB 미만의 스택을 가지므로
+       큰 자동 배열이나 중간 정도의 재귀는 스택 오버플로를 일으킬 수 있습니다. */
+    ASSERT(is_thread(t));
+    ASSERT(t->status == THREAD_RUNNING);
 
-	return t;
+    return t;
 }
 
 void thread_sleep(int64_t ticks)
 {
-	struct thread *curr = thread_current();
-	enum intr_level old_level;
+    struct thread *curr = thread_current();
+    enum intr_level old_level;
 
-	old_level = intr_disable();
-	if (curr != idle_thread)
-	{
-		curr->status = THREAD_BLOCKED;
-		curr->wakeup_tick = ticks;
-		list_insert_ordered(&sleep_list, &curr->elem, (list_less_func *)less, NULL);
-	}
-	schedule();
-	intr_set_level(old_level);
+    old_level = intr_disable();
+    if (curr != idle_thread)
+    {
+        curr->status = THREAD_BLOCKED;
+        curr->wakeup_tick = ticks;
+        list_insert_ordered(&sleep_list, &curr->elem, (list_less_func *)less, NULL);
+    }
+    schedule();
+    intr_set_level(old_level);
 }
 
 void thread_wakeup(int64_t ticks)
 {
-	if (list_empty(&sleep_list))
-		return;
+    if (list_empty(&sleep_list))
+        return;
 
-	enum intr_level old_level;
-	struct thread *to_wakeup = list_entry(list_front(&sleep_list), struct thread, elem);
+    enum intr_level old_level;
+    struct thread *to_wakeup = list_entry(list_front(&sleep_list), struct thread, elem);
 
-	old_level = intr_disable();
-	while (to_wakeup->wakeup_tick <= ticks)
-	{
-		list_pop_front(&sleep_list);
-		list_insert_ordered(&ready_list, &to_wakeup->elem, (list_less_func *)priority, NULL);
-		to_wakeup->status = THREAD_READY;
-		if (list_empty(&sleep_list))
-			return;
-		to_wakeup = list_entry(list_front(&sleep_list), struct thread, elem);
-	}
+    old_level = intr_disable();
+    while (to_wakeup->wakeup_tick <= ticks)
+    {
+        list_pop_front(&sleep_list);
+        list_insert_ordered(&ready_list, &to_wakeup->elem, (list_less_func *)priority, NULL);
+        to_wakeup->status = THREAD_READY;
+        if (list_empty(&sleep_list))
+            return;
+        to_wakeup = list_entry(list_front(&sleep_list), struct thread, elem);
+    }
 
-	intr_set_level(old_level);
+    intr_set_level(old_level);
 }
 
 /* Returns the running thread's tid.
    실행 중인 스레드의 tid를 반환합니다. */
 tid_t thread_tid(void)
 {
-	return thread_current()->tid;
+    return thread_current()->tid;
 }
 
 /* Deschedules the current thread and destroys it.  Never
@@ -486,21 +486,21 @@ tid_t thread_tid(void)
    절대 호출자에게 반환되지 않습니다. */
 void thread_exit(void)
 {
-	ASSERT(!intr_context());
+    ASSERT(!intr_context());
 
 #ifdef USERPROG
-	process_exit();
+    process_exit();
 #endif
 
-	/* Just set our status to dying and schedule another process.
-	   We will be destroyed during the call to schedule_tail().
+    /* Just set our status to dying and schedule another process.
+       We will be destroyed during the call to schedule_tail().
 
-	   그저 우리의 상태를 dying으로 설정하고 다른 프로세스를 스케줄합니다.
-	   schedule_tail() 호출 중에 우리는 파괴될 것입니다. */
+       그저 우리의 상태를 dying으로 설정하고 다른 프로세스를 스케줄합니다.
+       schedule_tail() 호출 중에 우리는 파괴될 것입니다. */
 
-	intr_disable();
-	do_schedule(THREAD_DYING);
-	NOT_REACHED();
+    intr_disable();
+    do_schedule(THREAD_DYING);
+    NOT_REACHED();
 }
 
 /* Yields the CPU.  The current thread is not put to sleep and
@@ -510,109 +510,109 @@ void thread_exit(void)
    스케줄러의 변덕에 따라 즉시 다시 예약될 수 있습니다.*/
 void thread_yield(void)
 {
-	struct thread *curr = thread_current(); // 현재 실행중인 스레드
-	enum intr_level old_level;
+    struct thread *curr = thread_current(); // 현재 실행중인 스레드
+    enum intr_level old_level;
 
-	ASSERT(!intr_context());
+    ASSERT(!intr_context());
 
-	old_level = intr_disable();
-	if (curr != idle_thread)
-	{
-		// list_push_back(&ready_list, &curr->elem);
-		list_insert_ordered(&ready_list, &curr->elem, priority, NULL);
-	}
+    old_level = intr_disable();
+    if (curr != idle_thread)
+    {
+        // list_push_back(&ready_list, &curr->elem);
+        list_insert_ordered(&ready_list, &curr->elem, priority, NULL);
+    }
 
-	// curr->nice++;
+    // curr->nice++;
 
-	do_schedule(THREAD_READY);
-	intr_set_level(old_level);
+    do_schedule(THREAD_READY);
+    intr_set_level(old_level);
 }
 
 /* Sets the current thread's priority to NEW_PRIORITY.
    현재 스레드의 우선순위를 NEW_PRIORITY로 설정합니다. */
 void thread_set_priority(int new_priority)
 {
-	struct thread *curr = thread_current();
-	curr->original = curr->priority = new_priority;
-	// if (!list_empty(&curr->donations))
-	// {
-	// 	curr->priority = list_entry(list_front(&curr->donations), struct thread, d_elem)
-	// 						 ->priority;
-	// }
+    struct thread *curr = thread_current();
+    curr->original = curr->priority = new_priority;
+    // if (!list_empty(&curr->donations))
+    // {
+    // 	curr->priority = list_entry(list_front(&curr->donations), struct thread, d_elem)
+    // 						 ->priority;
+    // }
 
-	if (list_empty(&ready_list))
-		return;
+    if (list_empty(&ready_list))
+        return;
 
-	list_sort(&ready_list, priority, NULL);
+    list_sort(&ready_list, priority, NULL);
 
-	struct thread *top_pri_th = list_entry(list_front(&ready_list), struct thread, elem);
-	int top_priority = top_pri_th->priority;
+    struct thread *top_pri_th = list_entry(list_front(&ready_list), struct thread, elem);
+    int top_priority = top_pri_th->priority;
 
-	if (top_priority > curr->priority)
-	{
-		thread_yield();
-	}
+    if (top_priority > curr->priority)
+    {
+        thread_yield();
+    }
 }
 
 /* Returns the current thread's priority.
    현재 스레드의 우선순위를 반환합니다. */
 int thread_get_priority(void)
 {
-	return thread_current()->priority;
+    return thread_current()->priority;
 }
 
 /* Sets the current thread's nice value to NICE.
    현재 스레드의 nice 값을 NICE로 설정합니다. */
 void thread_set_nice(int nice UNUSED)
 {
-	/* TODO: Your implementation goes here */
+    /* TODO: Your implementation goes here */
 }
 
 /* Returns the current thread's nice value.
    현재 스레드의 nice 값을 반환합니다. */
 int thread_get_nice(void)
 {
-	/* TODO: Your implementation goes here */
-	return 0;
+    /* TODO: Your implementation goes here */
+    return 0;
 }
 
 /* Returns 100 times the system load average.
    시스템 로드 평균의 100배를 반환합니다. */
 int thread_get_load_avg(void)
 {
-	/* TODO: Your implementation goes here */
+    /* TODO: Your implementation goes here */
 
-	return 0;
+    return 0;
 }
 
 /* Returns 100 times the current thread's recent_cpu value.
    현재 스레드의 recent_cpu 값을 100배한 값을 반환합니다. */
 int thread_get_recent_cpu(void)
 {
-	/* TODO: Your implementation goes here */
-	return 0;
+    /* TODO: Your implementation goes here */
+    return 0;
 }
 
 int calc_all_priority()
 {
-	while (thread_list) // ready + block + running - idle   th_elem
-	{
-		th->priority = PRI_MAX - (th->recent_cpu / 4) - (th->nice * 2);
-	}
+    while (thread_list) // ready + block + running - idle   th_elem
+    {
+        th->priority = PRI_MAX - (th->recent_cpu / 4) - (th->nice * 2);
+    }
 }
 
 int calc_load_avg()
 {
-	load_avg = (59 / 60) * load_avg + (1 / 60) * ready_threads; // ready_threads - running, ready 상태의 스레드 갯수
-	list_size(&ready_list) + 1;
+    load_avg = (59 / 60) * load_avg + (1 / 60) * ready_threads; // ready_threads - running, ready 상태의 스레드 갯수
+    list_size(&ready_list) + 1;
 }
 
 int calc_recent_cpu()
 {
-	while (thread_list)
-	{
-		th->recent_cpu = (2 * load_avg) / (2 * load_avg + 1) * th->recent_cpu + th->nice;
-	}
+    while (thread_list)
+    {
+        th->recent_cpu = (2 * load_avg) / (2 * load_avg + 1) * th->recent_cpu + th->nice;
+    }
 }
 
 int increase_cpu() // running th -> recent_cpu++  1 tick
@@ -645,41 +645,41 @@ int increase_cpu() // running th -> recent_cpu++  1 tick
 static void
 idle(void *idle_started_ UNUSED)
 {
-	struct semaphore *idle_started = idle_started_;
+    struct semaphore *idle_started = idle_started_;
 
-	idle_thread = thread_current();
-	sema_up(idle_started);
+    idle_thread = thread_current();
+    sema_up(idle_started);
 
-	for (;;)
-	{
-		/* Let someone else run. */
-		intr_disable();
-		thread_block();
+    for (;;)
+    {
+        /* Let someone else run. */
+        intr_disable();
+        thread_block();
 
-		/* Re-enable interrupts and wait for the next one.
+        /* Re-enable interrupts and wait for the next one.
 
-		   The `sti' instruction disables interrupts until the
-		   completion of the next instruction, so these two
-		   instructions are executed atomically.  This atomicity is
-		   important; otherwise, an interrupt could be handled
-		   between re-enabling interrupts and waiting for the next
-		   one to occur, wasting as much as one clock tick worth of
-		   time.
+           The `sti' instruction disables interrupts until the
+           completion of the next instruction, so these two
+           instructions are executed atomically.  This atomicity is
+           important; otherwise, an interrupt could be handled
+           between re-enabling interrupts and waiting for the next
+           one to occur, wasting as much as one clock tick worth of
+           time.
 
-		   See [IA32-v2a] "HLT", [IA32-v2b] "STI", and [IA32-v3a]
-		   7.11.1 "HLT Instruction".
+           See [IA32-v2a] "HLT", [IA32-v2b] "STI", and [IA32-v3a]
+           7.11.1 "HLT Instruction".
 
-		   다시 인터럽트를 활성화하고 다음 인터럽트를 기다립니다.
+           다시 인터럽트를 활성화하고 다음 인터럽트를 기다립니다.
 
-		   'sti' 명령은 다음 명령의 완료까지 인터럽트를 비활성화하므로
-		   이 두 명령은 원자적으로 실행됩니다. 이 원자성은 중요합니다.
-		   그렇지 않으면 인터럽트가 다시 활성화되고 다음 인터럽트를 기다리는 동안
-		   인터럽트가 처리될 수 있어서 최대 한 클럭 틱의 시간이 낭비될 수 있습니다.
+           'sti' 명령은 다음 명령의 완료까지 인터럽트를 비활성화하므로
+           이 두 명령은 원자적으로 실행됩니다. 이 원자성은 중요합니다.
+           그렇지 않으면 인터럽트가 다시 활성화되고 다음 인터럽트를 기다리는 동안
+           인터럽트가 처리될 수 있어서 최대 한 클럭 틱의 시간이 낭비될 수 있습니다.
 
-		   [IA32-v2a] "HLT", [IA32-v2b] "STI", [IA32-v3a]
-		   7.11.1 "HLT Instruction" 참조 */
-		asm volatile("sti; hlt" : : : "memory");
-	}
+           [IA32-v2a] "HLT", [IA32-v2b] "STI", [IA32-v3a]
+           7.11.1 "HLT Instruction" 참조 */
+        asm volatile("sti; hlt" : : : "memory");
+    }
 }
 
 /* Function used as the basis for a kernel thread.
@@ -687,11 +687,11 @@ idle(void *idle_started_ UNUSED)
 static void
 kernel_thread(thread_func *function, void *aux)
 {
-	ASSERT(function != NULL);
+    ASSERT(function != NULL);
 
-	intr_enable(); /* The scheduler runs with interrupts off. 스케쥴러가 인터럽트 없이 실행됩니다. */
-	function(aux); /* Execute the thread function. 스레드의 기능을 실행시킵니다. */
-	thread_exit(); /* If function() returns, kill the thread. 만약 function()이 반환되면, 스레드를 죽입니다. */
+    intr_enable(); /* The scheduler runs with interrupts off. 스케쥴러가 인터럽트 없이 실행됩니다. */
+    function(aux); /* Execute the thread function. 스레드의 기능을 실행시킵니다. */
+    thread_exit(); /* If function() returns, kill the thread. 만약 function()이 반환되면, 스레드를 죽입니다. */
 }
 
 /* Does basic initialization of T as a blocked thread named NAME.
@@ -699,21 +699,21 @@ kernel_thread(thread_func *function, void *aux)
 static void
 init_thread(struct thread *t, const char *name, int priority)
 {
-	ASSERT(t != NULL);
-	ASSERT(PRI_MIN <= priority && priority <= PRI_MAX);
-	ASSERT(name != NULL);
+    ASSERT(t != NULL);
+    ASSERT(PRI_MIN <= priority && priority <= PRI_MAX);
+    ASSERT(name != NULL);
 
-	memset(t, 0, sizeof *t);
-	t->status = THREAD_BLOCKED;
-	strlcpy(t->name, name, sizeof t->name);
-	t->tf.rsp = (uint64_t)t + PGSIZE - sizeof(void *);
-	t->priority = priority;
-	t->original = priority;
-	// printf("init pri %d  ori %d\n", t->priority, t->original);
-	t->magic = THREAD_MAGIC;
+    memset(t, 0, sizeof *t);
+    t->status = THREAD_BLOCKED;
+    strlcpy(t->name, name, sizeof t->name);
+    t->tf.rsp = (uint64_t)t + PGSIZE - sizeof(void *);
+    t->priority = priority;
+    t->original = priority;
+    // printf("init pri %d  ori %d\n", t->priority, t->original);
+    t->magic = THREAD_MAGIC;
 
-	t->nice = 0;
-	t->recent_cpu = 0;
+    t->nice = 0;
+    t->recent_cpu = 0;
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should
@@ -729,58 +729,58 @@ init_thread(struct thread *t, const char *name, int priority)
 static struct thread *
 next_thread_to_run(void)
 {
-	if (list_empty(&ready_list))
-	{
-		// printf("empty\n");
-		return idle_thread;
-	}
+    if (list_empty(&ready_list))
+    {
+        // printf("empty\n");
+        return idle_thread;
+    }
 
-	else
-	{
-		// list_sort(&ready_list, priority, NULL);
-		// printf("pri:   %d\n", list_entry(list_begin(&ready_list), struct thread, elem)->priority);
-		return list_entry(list_pop_front(&ready_list), struct thread, elem);
-	}
+    else
+    {
+        // list_sort(&ready_list, priority, NULL);
+        // printf("pri:   %d\n", list_entry(list_begin(&ready_list), struct thread, elem)->priority);
+        return list_entry(list_pop_front(&ready_list), struct thread, elem);
+    }
 }
 
 /* Use iretq to launch the thread
    스레드를 시작하기 위해 iretq를 사용합니다. */
 void do_iret(struct intr_frame *tf)
 {
-	__asm __volatile(
-		"movq %0, %%rsp\n"
-		"movq 0(%%rsp),%%r15\n"
-		"movq 8(%%rsp),%%r14\n"
-		"movq 16(%%rsp),%%r13\n"
-		"movq 24(%%rsp),%%r12\n"
-		"movq 32(%%rsp),%%r11\n"
-		"movq 40(%%rsp),%%r10\n"
-		"movq 48(%%rsp),%%r9\n"
-		"movq 56(%%rsp),%%r8\n"
-		"movq 64(%%rsp),%%rsi\n"
-		"movq 72(%%rsp),%%rdi\n"
-		"movq 80(%%rsp),%%rbp\n"
-		"movq 88(%%rsp),%%rdx\n"
-		"movq 96(%%rsp),%%rcx\n"
-		"movq 104(%%rsp),%%rbx\n"
-		"movq 112(%%rsp),%%rax\n"
-		"addq $120,%%rsp\n"
-		"movw 8(%%rsp),%%ds\n"
-		"movw (%%rsp),%%es\n"
-		"addq $32, %%rsp\n"
-		"iretq"
-		: : "g"((uint64_t)tf) : "memory");
+    __asm __volatile(
+        "movq %0, %%rsp\n"
+        "movq 0(%%rsp),%%r15\n"
+        "movq 8(%%rsp),%%r14\n"
+        "movq 16(%%rsp),%%r13\n"
+        "movq 24(%%rsp),%%r12\n"
+        "movq 32(%%rsp),%%r11\n"
+        "movq 40(%%rsp),%%r10\n"
+        "movq 48(%%rsp),%%r9\n"
+        "movq 56(%%rsp),%%r8\n"
+        "movq 64(%%rsp),%%rsi\n"
+        "movq 72(%%rsp),%%rdi\n"
+        "movq 80(%%rsp),%%rbp\n"
+        "movq 88(%%rsp),%%rdx\n"
+        "movq 96(%%rsp),%%rcx\n"
+        "movq 104(%%rsp),%%rbx\n"
+        "movq 112(%%rsp),%%rax\n"
+        "addq $120,%%rsp\n"
+        "movw 8(%%rsp),%%ds\n"
+        "movw (%%rsp),%%es\n"
+        "addq $32, %%rsp\n"
+        "iretq"
+        : : "g"((uint64_t)tf) : "memory");
 }
 
 /* Switching the thread by activating the new thread's page
    tables, and, if the previous thread is dying, destroying it.
-	새 스레드의 페이지테이블을 활성화 하는것으로 쓰레드를 전환한다.
-	이전 쓰레드가 죽어가는 쓰레드면 파괴한다.
+    새 스레드의 페이지테이블을 활성화 하는것으로 쓰레드를 전환한다.
+    이전 쓰레드가 죽어가는 쓰레드면 파괴한다.
    At this function's invocation, we just switched from thread
    PREV, the new thread is already running, and interrupts are
    still disabled.
-	이 함수의 부름(호출?) 시점에, 우리는 이전 쓰레드를 이제막 전환했고, 새 스레드는
-	이미 실행중이며, 인터럽트는 여전히 비활성화 되어있다.
+    이 함수의 부름(호출?) 시점에, 우리는 이전 쓰레드를 이제막 전환했고, 새 스레드는
+    이미 실행중이며, 인터럽트는 여전히 비활성화 되어있다.
    It's not safe to call printf() until the thread switch is
    complete.  In practice that means that printf()s should be
    added at the end of the function.
@@ -791,131 +791,131 @@ void do_iret(struct intr_frame *tf)
 static void
 thread_launch(struct thread *th)
 {
-	uint64_t tf_cur = (uint64_t)&running_thread()->tf;
-	uint64_t tf = (uint64_t)&th->tf;
-	ASSERT(intr_get_level() == INTR_OFF);
+    uint64_t tf_cur = (uint64_t)&running_thread()->tf;
+    uint64_t tf = (uint64_t)&th->tf;
+    ASSERT(intr_get_level() == INTR_OFF);
 
-	/* The main switching logic.
-	메인 문맥전환 로직
-	 * We first restore the whole execution context into the intr_frame
-	 먼저, 전체 실행문맥을 intr_frame에 저장한다.
-	 * and then switching to the next thread by calling do_iret.
-	 그리고 다음 스레드를 do_iret를 호출함으로써 switch한다.
-	 * Note that, we SHOULD NOT use any stack from here
-	 여기서는 문맥전환이 일어나기 까지 어떠한 stack도 써서는 안된다.
-	 * until switching is done. */
-	__asm __volatile(
-		/* Store registers that will be used.
-		 */
+    /* The main switching logic.
+    메인 문맥전환 로직
+     * We first restore the whole execution context into the intr_frame
+     먼저, 전체 실행문맥을 intr_frame에 저장한다.
+     * and then switching to the next thread by calling do_iret.
+     그리고 다음 스레드를 do_iret를 호출함으로써 switch한다.
+     * Note that, we SHOULD NOT use any stack from here
+     여기서는 문맥전환이 일어나기 까지 어떠한 stack도 써서는 안된다.
+     * until switching is done. */
+    __asm __volatile(
+        /* Store registers that will be used.
+         */
 
-		"push %%rax\n"
-		"push %%rbx\n"
-		"push %%rcx\n"
-		/* Fetch input once */
-		"movq %0, %%rax\n"
-		"movq %1, %%rcx\n"
-		"movq %%r15, 0(%%rax)\n"
-		"movq %%r14, 8(%%rax)\n"
-		"movq %%r13, 16(%%rax)\n"
-		"movq %%r12, 24(%%rax)\n"
-		"movq %%r11, 32(%%rax)\n"
-		"movq %%r10, 40(%%rax)\n"
-		"movq %%r9, 48(%%rax)\n"
-		"movq %%r8, 56(%%rax)\n"
-		"movq %%rsi, 64(%%rax)\n"
-		"movq %%rdi, 72(%%rax)\n"
-		"movq %%rbp, 80(%%rax)\n"
-		"movq %%rdx, 88(%%rax)\n"
-		"pop %%rbx\n" // Saved rcx
-		"movq %%rbx, 96(%%rax)\n"
-		"pop %%rbx\n" // Saved rbx
-		"movq %%rbx, 104(%%rax)\n"
-		"pop %%rbx\n" // Saved rax
-		"movq %%rbx, 112(%%rax)\n"
-		"addq $120, %%rax\n"
-		"movw %%es, (%%rax)\n"
-		"movw %%ds, 8(%%rax)\n"
-		"addq $32, %%rax\n"
-		"call __next\n" // read the current rip.
-		"__next:\n"
-		"pop %%rbx\n"
-		"addq $(out_iret -  __next), %%rbx\n"
-		"movq %%rbx, 0(%%rax)\n" // rip
-		"movw %%cs, 8(%%rax)\n"	 // cs
-		"pushfq\n"
-		"popq %%rbx\n"
-		"mov %%rbx, 16(%%rax)\n" // eflags
-		"mov %%rsp, 24(%%rax)\n" // rsp
-		"movw %%ss, 32(%%rax)\n"
-		"mov %%rcx, %%rdi\n"
-		"call do_iret\n"
-		"out_iret:\n"
-		: : "g"(tf_cur), "g"(tf) : "memory");
+        "push %%rax\n"
+        "push %%rbx\n"
+        "push %%rcx\n"
+        /* Fetch input once */
+        "movq %0, %%rax\n"
+        "movq %1, %%rcx\n"
+        "movq %%r15, 0(%%rax)\n"
+        "movq %%r14, 8(%%rax)\n"
+        "movq %%r13, 16(%%rax)\n"
+        "movq %%r12, 24(%%rax)\n"
+        "movq %%r11, 32(%%rax)\n"
+        "movq %%r10, 40(%%rax)\n"
+        "movq %%r9, 48(%%rax)\n"
+        "movq %%r8, 56(%%rax)\n"
+        "movq %%rsi, 64(%%rax)\n"
+        "movq %%rdi, 72(%%rax)\n"
+        "movq %%rbp, 80(%%rax)\n"
+        "movq %%rdx, 88(%%rax)\n"
+        "pop %%rbx\n" // Saved rcx
+        "movq %%rbx, 96(%%rax)\n"
+        "pop %%rbx\n" // Saved rbx
+        "movq %%rbx, 104(%%rax)\n"
+        "pop %%rbx\n" // Saved rax
+        "movq %%rbx, 112(%%rax)\n"
+        "addq $120, %%rax\n"
+        "movw %%es, (%%rax)\n"
+        "movw %%ds, 8(%%rax)\n"
+        "addq $32, %%rax\n"
+        "call __next\n" // read the current rip.
+        "__next:\n"
+        "pop %%rbx\n"
+        "addq $(out_iret -  __next), %%rbx\n"
+        "movq %%rbx, 0(%%rax)\n" // rip
+        "movw %%cs, 8(%%rax)\n"  // cs
+        "pushfq\n"
+        "popq %%rbx\n"
+        "mov %%rbx, 16(%%rax)\n" // eflags
+        "mov %%rsp, 24(%%rax)\n" // rsp
+        "movw %%ss, 32(%%rax)\n"
+        "mov %%rcx, %%rdi\n"
+        "call do_iret\n"
+        "out_iret:\n"
+        : : "g"(tf_cur), "g"(tf) : "memory");
 }
 
 /* Schedules a new process. At entry, interrupts must be off.
-	새로운 프로세스를 스케줄링하라. 처음에 interrupts가 꺼져있어야한다.
+    새로운 프로세스를 스케줄링하라. 처음에 interrupts가 꺼져있어야한다.
  * This function modify current thread's status to status and then
-	이 함수는 현재 스레드의 상태를 다른 상태로 조정하고
+    이 함수는 현재 스레드의 상태를 다른 상태로 조정하고
  * finds another thread to run and switches to it.
-	cpu에 돌릴 다른 스레드를 찾아 그것으로 바꾼다.
+    cpu에 돌릴 다른 스레드를 찾아 그것으로 바꾼다.
  * It's not safe to call printf() in the schedule().
-	schedule내에서 printf를 찍는건 안전치않다. */
+    schedule내에서 printf를 찍는건 안전치않다. */
 static void
 do_schedule(int status)
 {
-	ASSERT(intr_get_level() == INTR_OFF);
-	ASSERT(thread_current()->status == THREAD_RUNNING);
-	while (!list_empty(&destruction_req))
-	{
-		struct thread *victim =
-			list_entry(list_pop_front(&destruction_req), struct thread, elem);
-		palloc_free_page(victim);
-	}
-	thread_current()->status = status;
-	schedule();
+    ASSERT(intr_get_level() == INTR_OFF);
+    ASSERT(thread_current()->status == THREAD_RUNNING);
+    while (!list_empty(&destruction_req))
+    {
+        struct thread *victim =
+            list_entry(list_pop_front(&destruction_req), struct thread, elem);
+        palloc_free_page(victim);
+    }
+    thread_current()->status = status;
+    schedule();
 }
 
 static void
 schedule(void)
 {
-	struct thread *curr = running_thread();
-	struct thread *next = next_thread_to_run();
+    struct thread *curr = running_thread();
+    struct thread *next = next_thread_to_run();
 
-	ASSERT(intr_get_level() == INTR_OFF);
-	ASSERT(curr->status != THREAD_RUNNING);
-	ASSERT(is_thread(next));
-	/* Mark us as running. */
-	next->status = THREAD_RUNNING;
+    ASSERT(intr_get_level() == INTR_OFF);
+    ASSERT(curr->status != THREAD_RUNNING);
+    ASSERT(is_thread(next));
+    /* Mark us as running. */
+    next->status = THREAD_RUNNING;
 
-	/* Start new time slice.
-	새로운 쓰레드틱스??*/
-	thread_ticks = 0;
+    /* Start new time slice.
+    새로운 쓰레드틱스??*/
+    thread_ticks = 0;
 
 #ifdef USERPROG
-	/* Activate the new address space. */
-	process_activate(next);
+    /* Activate the new address space. */
+    process_activate(next);
 #endif
 
-	if (curr != next)
-	{
-		/* If the thread we switched from is dying, destroy its struct
-		   thread. This must happen late so that thread_exit() doesn't
-		   pull out the rug under itself.
-		   We just queuing the page free reqeust here because the page is
-		   currently used by the stack.
-		   The real destruction logic will be called at the beginning of the
-		   schedule(). */
-		if (curr && curr->status == THREAD_DYING && curr != initial_thread)
-		{
-			ASSERT(curr != next);
-			list_push_back(&destruction_req, &curr->elem);
-		}
+    if (curr != next)
+    {
+        /* If the thread we switched from is dying, destroy its struct
+           thread. This must happen late so that thread_exit() doesn't
+           pull out the rug under itself.
+           We just queuing the page free reqeust here because the page is
+           currently used by the stack.
+           The real destruction logic will be called at the beginning of the
+           schedule(). */
+        if (curr && curr->status == THREAD_DYING && curr != initial_thread)
+        {
+            ASSERT(curr != next);
+            list_push_back(&destruction_req, &curr->elem);
+        }
 
-		/* Before switching the thread, we first save the information
-		 * of current running. */
-		thread_launch(next);
-	}
+        /* Before switching the thread, we first save the information
+         * of current running. */
+        thread_launch(next);
+    }
 }
 
 /* Returns a tid to use for a new thread.
@@ -924,12 +924,23 @@ schedule(void)
 static tid_t
 allocate_tid(void)
 {
-	static tid_t next_tid = 1; // 정적변수. 증가시키면서 할당할 스레드ID값
-	tid_t tid;
+    static tid_t next_tid = 1; // 정적변수. 증가시키면서 할당할 스레드ID값
+    tid_t tid;
 
-	lock_acquire(&tid_lock); // tid들이 경쟁적으로 가져갈 lock키의 주소를 얻음
-	tid = next_tid++;		 //  tid에 다음tid 할당
-	lock_release(&tid_lock); //
+    lock_acquire(&tid_lock); // tid들이 경쟁적으로 가져갈 lock키의 주소를 얻음
+    tid = next_tid++;        //  tid에 다음tid 할당
+    lock_release(&tid_lock); //
 
-	return tid;
+    return tid;
+}
+
+/* Calculate one threads' priority. */
+void calc_one_priority(struct thread *t)
+{
+    double recent_cpu = t->recent_cpu;
+    int nice = t->nice;
+
+    int priority = PRI_MAX - (((int64_t)recent_cpu) * f / 4) - (nice * 2);
+
+    return priority;
 }


### PR DESCRIPTION
mlfqs-load-60
- priority 계산식에서 `recent_cpu` 값을 고정 소수점 -> 일반 정수로 변환 후 계산하도록 변경.
해당 과정에서 매크로 `TOINT_ZERO`를 추가.
- priority MAX, MIN 한계를 고정하지 않았었기 때문에 priority가 200, 300을 넘어서는 상태였음. 한계값을 넘지 못하도록 조정.

mlfqs-load-avg, mlfqs-recent-1
- `thread_list`에 main 스레드가 포함되지 않는 상태였음. main 스레드를 포함할 수 있도록
`list_push_back(&thread_list, t->th_elem)`의 호출 위치를 `thread_create()`에서 `init_thread()`로 변경하였음.
- `thread_set_nice()`에서 `thread_yield()`를 호출하지 않게 변경.
/ 했었으나 `thread_yield()`를 호출해도 테스트는 통과가 됨. 동작에 영향을 주지 않는 것으로 확인되었음.

이 후, mlfqs-block, mlfqs-nice-2, mlfqs-nice-20, mlfqs-fair-2, mlfqs-fair-20 모두 통과하였음.