### PR TITLE
Syscall

### DIFF
--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -126,6 +126,8 @@ struct thread
     struct intr_frame tf; /* Information for switching */
     unsigned magic;       /* Detects stack overflow. */
     int64_t wakeup_tick;  /* 쓰레드가 wake-up할 tick(local tick)*/
+    struct file *fdt[128];
+    int exit_status; /* exit status */
 };
 
 /* If false (default), use round-robin scheduler.

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -126,8 +126,9 @@ struct thread
     struct intr_frame tf; /* Information for switching */
     unsigned magic;       /* Detects stack overflow. */
     int64_t wakeup_tick;  /* 쓰레드가 wake-up할 tick(local tick)*/
+    int exit_status;      /* exit status */
     struct file *fdt[128];
-    int exit_status; /* exit status */
+    int next_fd;
 };
 
 /* If false (default), use round-robin scheduler.

--- a/include/userprog/process.h
+++ b/include/userprog/process.h
@@ -3,11 +3,14 @@
 
 #include "threads/thread.h"
 
-tid_t process_create_initd (const char *file_name);
-tid_t process_fork (const char *name, struct intr_frame *if_);
-int process_exec (void *f_name);
-int process_wait (tid_t);
-void process_exit (void);
-void process_activate (struct thread *next);
+tid_t process_create_initd(const char *file_name);
+tid_t process_fork(const char *name, struct intr_frame *if_);
+int process_exec(void *f_name);
+int process_wait(tid_t);
+void process_exit(void);
+int process_add_file(struct file *f);
+void process_activate(struct thread *next);
+void process_close_file(int fd);
+int process_get_file(int fd);
 
 #endif /* userprog/process.h */

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -142,7 +142,8 @@ void sema_up(struct semaphore *sema)
     }
     sema->value++;
 
-    thread_yield(); // thread_preempt();
+    // thread_yield();
+    thread_try_yield();
     intr_set_level(old_level);
 }
 

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -793,6 +793,7 @@ init_thread(struct thread *t, const char *name, int priority)
     list_init(&t->donations);
     t->nice = 0;
     t->recent_cpu = 0;
+    t->exit_status = 0;
 
     if (strcmp(name, "idle"))
         list_push_back(&thread_list, &t->th_elem);

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -538,9 +538,16 @@ void thread_yield(void)
         // list_push_back(&ready_list, &curr->elem);
         list_insert_ordered(&ready_list, &curr->elem, priority, NULL);
     }
-
     do_schedule(THREAD_READY);
     intr_set_level(old_level);
+}
+
+void thread_try_yield(void)
+{
+    if (!intr_context() && !list_empty(&ready_list) && thread_current() != idle_thread)
+    {
+        thread_yield();
+    }
 }
 
 /* Sets the current thread's priority to NEW_PRIORITY.

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -97,6 +97,7 @@ static struct list thread_list;
 #define TOINT(x) (x >= 0) ? ((x + ((1 << FIXED) >> 1)) >> FIXED) : ((x - ((1 << FIXED) >> 1)) >> FIXED)
 #define TOINT_ZERO(x) ((x) >> FIXED)
 #define TOFIX(x) (x << FIXED)
+#define FDT_PAGES 2
 
 static void kernel_thread(thread_func *, void *aux);
 
@@ -342,6 +343,11 @@ tid_t thread_create(const char *name, int priority,
     t->tf.ss = SEL_KDSEG;
     t->tf.cs = SEL_KCSEG;
     t->tf.eflags = FLAG_IF;
+
+    for (int i = 0; i < 128; i++)
+    {
+        thread_current()->fdt[i] = NULL;
+    }
 
     /* Add to run queue.
        실행 큐에 추가 */
@@ -794,6 +800,7 @@ init_thread(struct thread *t, const char *name, int priority)
     t->nice = 0;
     t->recent_cpu = 0;
     t->exit_status = 0;
+    t->next_fd = 2;
 
     if (strcmp(name, "idle"))
         list_push_back(&thread_list, &t->th_elem);

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -281,20 +281,6 @@ void process_activate(struct thread *next)
     tss_update(next);
 }
 
-int process_add_file(struct file *f)
-{
-    struct thread *t = thread_current();
-    for (int i = 2; i < 128; i++)
-    {
-        if (t->fdt[i] == NULL)
-        {
-            t->fdt[i] = f;
-            return i;
-        }
-        return -1;
-    }
-}
-
 /* We load ELF binaries.  The following definitions are taken
  * from the ELF specification, [ELF1], more-or-less verbatim.  */
 
@@ -516,6 +502,36 @@ void push_stack(struct intr_frame *intr_f, char **argv, int argc)
 
     intr_f->R.rdi = argc;
     intr_f->R.rsi = intr_f->rsp + 8;
+}
+
+int process_add_file(struct file *f)
+{
+    struct thread *t = thread_current();
+    for (int i = 2; i < 128; i++)
+    {
+        if (t->fdt[i] == NULL)
+        {
+            t->fdt[i] = f;
+            return i;
+        }
+    }
+    return -1;
+}
+
+int process_get_file(int fd)
+{
+    struct thread *t = thread_current();
+    if (t->fdt[fd] == NULL)
+    {
+        return -1;
+    }
+    return fd;
+}
+
+void process_close_file(int fd)
+{
+    struct thread *curr = thread_current();
+    curr->fdt[fd] = NULL;
 }
 
 /* Checks whether PHDR describes a valid, loadable segment in

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -458,7 +458,7 @@ load(const char *file_name, struct intr_frame *if_)
      * TODO: Implement argument passing (see project2/argument_passing.html). */
 
     push_stack(if_, argv, argc);
-    hex_dump(if_->rsp, if_->rsp, USER_STACK - (uint64_t)if_->rsp, true);
+    // hex_dump(if_->rsp, if_->rsp, USER_STACK - (uint64_t)if_->rsp, true);
 
     success = true;
 
@@ -494,8 +494,8 @@ void push_stack(struct intr_frame *intr_f, char **argv, int argc)
     intr_f->rsp = intr_f->rsp - sizeof(void (*)()); // return할 함수가 있을 시 return address 설정
     memset((void *)intr_f->rsp, 0, sizeof(void (*)()));
 
-    intr_f->R.rsi = argv[0];
     intr_f->R.rdi = argc;
+    intr_f->R.rsi = intr_f->rsp + 8;
 }
 
 /* Checks whether PHDR describes a valid, loadable segment in

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -194,8 +194,6 @@ int process_exec(void *f_name)
     /* We first kill the current context */
     process_cleanup();
 
-    // printf("파일 이름 전체: %s \n\n", file_name);
-
     /* And then load the binary */
     success = load(file_name, &_if);
 
@@ -375,9 +373,6 @@ load(const char *file_name, struct intr_frame *if_)
     }
     file_name = argv[0];
 
-    // printf("argv에 들어온 파일 이름: %s \n\n", file_name);
-    // printf("argv에 들어온 인자 이름: %s \n\n", argv[1]);
-
     /* Open executable file. */
     file = filesys_open(file_name);
     if (file == NULL)
@@ -458,12 +453,10 @@ load(const char *file_name, struct intr_frame *if_)
 
     /* Start address. */
     if_->rip = ehdr.e_entry;
-    // printf("초기 rsp 위치: %x \n\n", if_->rsp);
-    // printf("초기 rdi 값: %d \n\n", if_->R.rdi);
+
     /* TODO: Your code goes here.
      * TODO: Implement argument passing (see project2/argument_passing.html). */
 
-    // printf("argv배열 실험 %s, %s \n\n", *argv, argv[0]);
     push_stack(if_, argv, argc);
     hex_dump(if_->rsp, if_->rsp, USER_STACK - (uint64_t)if_->rsp, true);
 
@@ -479,35 +472,23 @@ void push_stack(struct intr_frame *intr_f, char **argv, int argc)
 {
     char *addrv[128];
 
-    // printf("argv 배열 원소 %s, %s \n\n", argv[0], argv[1]);
-    // printf("argc 개수: %d \n\n", argc);
-
     for (int i = argc - 1; i >= 0; i--) // 명령어 인자 데이터 넣기
     {
         size_t len = strlen(argv[i]) + 1;
         intr_f->rsp -= len;
-        // printf("데이터 push rsp -> %llx \n\n", intr_f->rsp);
         memcpy((void *)intr_f->rsp, argv[i], len);
         addrv[i] = intr_f->rsp;
-        // printf("addrv에 넣은 주소: %x \n\n", addrv[i]);
     }
     intr_f->rsp = intr_f->rsp - sizeof(uint8_t *); // 스택 포인터를 8의 배수로 반올림
     memset((void *)intr_f->rsp, 0, sizeof(uint8_t *));
-    // printf("rsp 위치: %x \n\n", intr_f->rsp);
 
     intr_f->rsp = intr_f->rsp - sizeof(char *); // 스택 포인터를 8의 배수로 반올림
     memset((void *)intr_f->rsp, 0, sizeof(char *));
-    // printf("rsp 위치: %x \n\n", intr_f->rsp);
-    // printf("data push 이후 rsp값 %x \n\n", intr_f->rsp);
-    // printf("addrv[1]에 넣은 주소: %x \n\n", addrv[1]);
-    // printf("addrv[0]에 넣은 주소: %x \n\n", addrv[0]);
 
     for (int j = argc - 1; j >= 0; j--)
     {
         intr_f->rsp -= sizeof(char *);
-        // printf("addrv[j]에 넣은 주소: %x \n\n", addrv[j]);
         memcpy((void *)intr_f->rsp, &addrv[j], sizeof(char *));
-        // printf("주소 push rsp -> %llx \n\n", intr_f->rsp);
     }
 
     intr_f->rsp = intr_f->rsp - sizeof(void (*)()); // return할 함수가 있을 시 return address 설정
@@ -515,7 +496,6 @@ void push_stack(struct intr_frame *intr_f, char **argv, int argc)
 
     intr_f->R.rsi = argv[0];
     intr_f->R.rdi = argc;
-    // printf("address push 이후 rsp값 %x \n\n", intr_f->rsp);
 }
 
 /* Checks whether PHDR describes a valid, loadable segment in

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -221,7 +221,8 @@ int process_wait(tid_t child_tid UNUSED)
     /* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
      * XXX:       to add infinite loop here before
      * XXX:       implementing the process_wait. */
-    for (int i = 0; i = 10000; i++)
+
+    for (int i = 1; i < 1000000000; i++)
     {
         continue;
     }
@@ -236,8 +237,8 @@ void process_exit(void)
      * TODO: Implement process termination message (see
      * TODO: project2/process_termination.html).
      * TODO: We recommend you to implement process resource cleanup here. */
-
     process_cleanup();
+    // printf("%s: exit(%d)\n", thread_current()->name, curr->exit_status);
 }
 
 /* Free the current process's resources. */

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -22,15 +22,16 @@
 #include "vm/vm.h"
 #endif
 
-static void process_cleanup (void);
-static bool load (const char *file_name, struct intr_frame *if_);
-static void initd (void *f_name);
-static void __do_fork (void *);
+static void process_cleanup(void);
+static bool load(const char *file_name, struct intr_frame *if_);
+static void initd(void *f_name);
+static void __do_fork(void *);
 
 /* General process initializer for initd and other process. */
 static void
-process_init (void) {
-	struct thread *current = thread_current ();
+process_init(void)
+{
+    struct thread *current = thread_current();
 }
 
 /* Starts the first userland program, called "initd", loaded from FILE_NAME.
@@ -38,77 +39,92 @@ process_init (void) {
  * before process_create_initd() returns. Returns the initd's
  * thread id, or TID_ERROR if the thread cannot be created.
  * Notice that THIS SHOULD BE CALLED ONCE. */
-tid_t
-process_create_initd (const char *file_name) {
-	char *fn_copy;
-	tid_t tid;
+tid_t process_create_initd(const char *file_name)
+{
+    char *fn_copy;
+    char s[128][14];
+    char *token, *save_ptr;
+    int d = 0;
+    tid_t tid;
 
-	/* Make a copy of FILE_NAME.
-	 * Otherwise there's a race between the caller and load(). */
-	fn_copy = palloc_get_page (0);
-	if (fn_copy == NULL)
-		return TID_ERROR;
-	strlcpy (fn_copy, file_name, PGSIZE);
+    /* Make a copy of FILE_NAME.
+     * Otherwise there's a race between the caller and load(). */
+    fn_copy = palloc_get_page(0);
+    if (fn_copy == NULL)
+        return TID_ERROR;
+    strlcpy(fn_copy, file_name, PGSIZE);
 
-	/* Create a new thread to execute FILE_NAME. */
-	tid = thread_create (file_name, PRI_DEFAULT, initd, fn_copy);
-	if (tid == TID_ERROR)
-		palloc_free_page (fn_copy);
-	return tid;
+    for (token = strtok_r(fn_copy, " ", &save_ptr);
+         token != NULL;
+         token = strtok_r(NULL, " ", &save_ptr))
+    {
+        strlcpy(s[d], token, 128);
+        d++;
+    }
+    file_name = s[0];
+
+    /* Create a new thread to execute FILE_NAME. */
+    tid = thread_create(file_name, PRI_DEFAULT, initd, fn_copy);
+    if (tid == TID_ERROR)
+        palloc_free_page(fn_copy);
+    return tid;
 }
 
 /* A thread function that launches first user process. */
 static void
-initd (void *f_name) {
+initd(void *f_name)
+{
 #ifdef VM
-	supplemental_page_table_init (&thread_current ()->spt);
+    supplemental_page_table_init(&thread_current()->spt);
 #endif
 
-	process_init ();
+    process_init();
 
-	if (process_exec (f_name) < 0)
-		PANIC("Fail to launch initd\n");
-	NOT_REACHED ();
+    if (process_exec(f_name) < 0)
+        PANIC("Fail to launch initd\n");
+    NOT_REACHED();
 }
 
 /* Clones the current process as `name`. Returns the new process's thread id, or
  * TID_ERROR if the thread cannot be created. */
-tid_t
-process_fork (const char *name, struct intr_frame *if_ UNUSED) {
-	/* Clone current thread to new thread.*/
-	return thread_create (name,
-			PRI_DEFAULT, __do_fork, thread_current ());
+tid_t process_fork(const char *name, struct intr_frame *if_ UNUSED)
+{
+    /* Clone current thread to new thread.*/
+    return thread_create(name,
+                         PRI_DEFAULT, __do_fork, thread_current());
 }
 
 #ifndef VM
 /* Duplicate the parent's address space by passing this function to the
  * pml4_for_each. This is only for the project 2. */
 static bool
-duplicate_pte (uint64_t *pte, void *va, void *aux) {
-	struct thread *current = thread_current ();
-	struct thread *parent = (struct thread *) aux;
-	void *parent_page;
-	void *newpage;
-	bool writable;
+duplicate_pte(uint64_t *pte, void *va, void *aux)
+{
+    struct thread *current = thread_current();
+    struct thread *parent = (struct thread *)aux;
+    void *parent_page;
+    void *newpage;
+    bool writable;
 
-	/* 1. TODO: If the parent_page is kernel page, then return immediately. */
+    /* 1. TODO: If the parent_page is kernel page, then return immediately. */
 
-	/* 2. Resolve VA from the parent's page map level 4. */
-	parent_page = pml4_get_page (parent->pml4, va);
+    /* 2. Resolve VA from the parent's page map level 4. */
+    parent_page = pml4_get_page(parent->pml4, va);
 
-	/* 3. TODO: Allocate new PAL_USER page for the child and set result to
-	 *    TODO: NEWPAGE. */
+    /* 3. TODO: Allocate new PAL_USER page for the child and set result to
+     *    TODO: NEWPAGE. */
 
-	/* 4. TODO: Duplicate parent's page to the new page and
-	 *    TODO: check whether parent's page is writable or not (set WRITABLE
-	 *    TODO: according to the result). */
+    /* 4. TODO: Duplicate parent's page to the new page and
+     *    TODO: check whether parent's page is writable or not (set WRITABLE
+     *    TODO: according to the result). */
 
-	/* 5. Add new page to child's page table at address VA with WRITABLE
-	 *    permission. */
-	if (!pml4_set_page (current->pml4, va, newpage, writable)) {
-		/* 6. TODO: if fail to insert page, do error handling. */
-	}
-	return true;
+    /* 5. Add new page to child's page table at address VA with WRITABLE
+     *    permission. */
+    if (!pml4_set_page(current->pml4, va, newpage, writable))
+    {
+        /* 6. TODO: if fail to insert page, do error handling. */
+    }
+    return true;
 }
 #endif
 
@@ -117,78 +133,78 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
  *       That is, you are required to pass second argument of process_fork to
  *       this function. */
 static void
-__do_fork (void *aux) {
-	struct intr_frame if_;
-	struct thread *parent = (struct thread *) aux;
-	struct thread *current = thread_current ();
-	/* TODO: somehow pass the parent_if. (i.e. process_fork()'s if_) */
-	struct intr_frame *parent_if;
-	bool succ = true;
+__do_fork(void *aux)
+{
+    struct intr_frame if_;
+    struct thread *parent = (struct thread *)aux;
+    struct thread *current = thread_current();
+    /* TODO: somehow pass the parent_if. (i.e. process_fork()'s if_) */
+    struct intr_frame *parent_if;
+    bool succ = true;
 
-	/* 1. Read the cpu context to local stack. */
-	memcpy (&if_, parent_if, sizeof (struct intr_frame));
+    /* 1. Read the cpu context to local stack. */
+    memcpy(&if_, parent_if, sizeof(struct intr_frame));
 
-	/* 2. Duplicate PT */
-	current->pml4 = pml4_create();
-	if (current->pml4 == NULL)
-		goto error;
+    /* 2. Duplicate PT */
+    current->pml4 = pml4_create();
+    if (current->pml4 == NULL)
+        goto error;
 
-	process_activate (current);
+    process_activate(current);
 #ifdef VM
-	supplemental_page_table_init (&current->spt);
-	if (!supplemental_page_table_copy (&current->spt, &parent->spt))
-		goto error;
+    supplemental_page_table_init(&current->spt);
+    if (!supplemental_page_table_copy(&current->spt, &parent->spt))
+        goto error;
 #else
-	if (!pml4_for_each (parent->pml4, duplicate_pte, parent))
-		goto error;
+    if (!pml4_for_each(parent->pml4, duplicate_pte, parent))
+        goto error;
 #endif
 
-	/* TODO: Your code goes here.
-	 * TODO: Hint) To duplicate the file object, use `file_duplicate`
-	 * TODO:       in include/filesys/file.h. Note that parent should not return
-	 * TODO:       from the fork() until this function successfully duplicates
-	 * TODO:       the resources of parent.*/
+    /* TODO: Your code goes here.
+     * TODO: Hint) To duplicate the file object, use `file_duplicate`
+     * TODO:       in include/filesys/file.h. Note that parent should not return
+     * TODO:       from the fork() until this function successfully duplicates
+     * TODO:       the resources of parent.*/
 
-	process_init ();
+    process_init();
 
-	/* Finally, switch to the newly created process. */
-	if (succ)
-		do_iret (&if_);
+    /* Finally, switch to the newly created process. */
+    if (succ)
+        do_iret(&if_);
 error:
-	thread_exit ();
+    thread_exit();
 }
 
 /* Switch the current execution context to the f_name.
  * Returns -1 on fail. */
-int
-process_exec (void *f_name) {
-	char *file_name = f_name;
-	bool success;
+int process_exec(void *f_name)
+{
+    char *file_name = f_name;
+    bool success;
 
-	/* We cannot use the intr_frame in the thread structure.
-	 * This is because when current thread rescheduled,
-	 * it stores the execution information to the member. */
-	struct intr_frame _if;
-	_if.ds = _if.es = _if.ss = SEL_UDSEG;
-	_if.cs = SEL_UCSEG;
-	_if.eflags = FLAG_IF | FLAG_MBS;
+    /* We cannot use the intr_frame in the thread structure.
+     * This is because when current thread rescheduled,
+     * it stores the execution information to the member. */
+    struct intr_frame _if;
+    _if.ds = _if.es = _if.ss = SEL_UDSEG;
+    _if.cs = SEL_UCSEG;
+    _if.eflags = FLAG_IF | FLAG_MBS;
 
-	/* We first kill the current context */
-	process_cleanup ();
+    /* We first kill the current context */
+    process_cleanup();
 
-	/* And then load the binary */
-	success = load (file_name, &_if);
+    /* And then load the binary */
+    success = load(file_name, &_if);
 
-	/* If load failed, quit. */
-	palloc_free_page (file_name);
-	if (!success)
-		return -1;
+    /* If load failed, quit. */
+    palloc_free_page(file_name);
+    if (!success)
+        return -1;
 
-	/* Start switched process. */
-	do_iret (&_if);
-	NOT_REACHED ();
+    /* Start switched process. */
+    do_iret(&_if);
+    NOT_REACHED();
 }
-
 
 /* Waits for thread TID to die and returns its exit status.  If
  * it was terminated by the kernel (i.e. killed due to an
@@ -199,62 +215,68 @@ process_exec (void *f_name) {
  *
  * This function will be implemented in problem 2-2.  For now, it
  * does nothing. */
-int
-process_wait (tid_t child_tid UNUSED) {
-	/* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
-	 * XXX:       to add infinite loop here before
-	 * XXX:       implementing the process_wait. */
-	return -1;
+int process_wait(tid_t child_tid UNUSED)
+{
+    /* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
+     * XXX:       to add infinite loop here before
+     * XXX:       implementing the process_wait. */
+    for (int i = 0; i = 1000000; i++)
+    {
+        continue;
+    }
+    return -1;
 }
 
 /* Exit the process. This function is called by thread_exit (). */
-void
-process_exit (void) {
-	struct thread *curr = thread_current ();
-	/* TODO: Your code goes here.
-	 * TODO: Implement process termination message (see
-	 * TODO: project2/process_termination.html).
-	 * TODO: We recommend you to implement process resource cleanup here. */
+void process_exit(void)
+{
+    struct thread *curr = thread_current();
+    /* TODO: Your code goes here.
+     * TODO: Implement process termination message (see
+     * TODO: project2/process_termination.html).
+     * TODO: We recommend you to implement process resource cleanup here. */
 
-	process_cleanup ();
+    process_cleanup();
 }
 
 /* Free the current process's resources. */
 static void
-process_cleanup (void) {
-	struct thread *curr = thread_current ();
+process_cleanup(void)
+{
+    struct thread *curr = thread_current();
 
 #ifdef VM
-	supplemental_page_table_kill (&curr->spt);
+    supplemental_page_table_kill(&curr->spt);
 #endif
 
-	uint64_t *pml4;
-	/* Destroy the current process's page directory and switch back
-	 * to the kernel-only page directory. */
-	pml4 = curr->pml4;
-	if (pml4 != NULL) {
-		/* Correct ordering here is crucial.  We must set
-		 * cur->pagedir to NULL before switching page directories,
-		 * so that a timer interrupt can't switch back to the
-		 * process page directory.  We must activate the base page
-		 * directory before destroying the process's page
-		 * directory, or our active page directory will be one
-		 * that's been freed (and cleared). */
-		curr->pml4 = NULL;
-		pml4_activate (NULL);
-		pml4_destroy (pml4);
-	}
+    uint64_t *pml4;
+    /* Destroy the current process's page directory and switch back
+     * to the kernel-only page directory. */
+    pml4 = curr->pml4;
+    if (pml4 != NULL)
+    {
+        /* Correct ordering here is crucial.  We must set
+         * cur->pagedir to NULL before switching page directories,
+         * so that a timer interrupt can't switch back to the
+         * process page directory.  We must activate the base page
+         * directory before destroying the process's page
+         * directory, or our active page directory will be one
+         * that's been freed (and cleared). */
+        curr->pml4 = NULL;
+        pml4_activate(NULL);
+        pml4_destroy(pml4);
+    }
 }
 
 /* Sets up the CPU for running user code in the nest thread.
  * This function is called on every context switch. */
-void
-process_activate (struct thread *next) {
-	/* Activate thread's page tables. */
-	pml4_activate (next->pml4);
+void process_activate(struct thread *next)
+{
+    /* Activate thread's page tables. */
+    pml4_activate(next->pml4);
 
-	/* Set thread's kernel stack for use in processing interrupts. */
-	tss_update (next);
+    /* Set thread's kernel stack for use in processing interrupts. */
+    tss_update(next);
 }
 
 /* We load ELF binaries.  The following definitions are taken
@@ -263,211 +285,216 @@ process_activate (struct thread *next) {
 /* ELF types.  See [ELF1] 1-2. */
 #define EI_NIDENT 16
 
-#define PT_NULL    0            /* Ignore. */
-#define PT_LOAD    1            /* Loadable segment. */
-#define PT_DYNAMIC 2            /* Dynamic linking info. */
-#define PT_INTERP  3            /* Name of dynamic loader. */
-#define PT_NOTE    4            /* Auxiliary info. */
-#define PT_SHLIB   5            /* Reserved. */
-#define PT_PHDR    6            /* Program header table. */
-#define PT_STACK   0x6474e551   /* Stack segment. */
+#define PT_NULL 0           /* Ignore. */
+#define PT_LOAD 1           /* Loadable segment. */
+#define PT_DYNAMIC 2        /* Dynamic linking info. */
+#define PT_INTERP 3         /* Name of dynamic loader. */
+#define PT_NOTE 4           /* Auxiliary info. */
+#define PT_SHLIB 5          /* Reserved. */
+#define PT_PHDR 6           /* Program header table. */
+#define PT_STACK 0x6474e551 /* Stack segment. */
 
-#define PF_X 1          /* Executable. */
-#define PF_W 2          /* Writable. */
-#define PF_R 4          /* Readable. */
+#define PF_X 1 /* Executable. */
+#define PF_W 2 /* Writable. */
+#define PF_R 4 /* Readable. */
 
 /* Executable header.  See [ELF1] 1-4 to 1-8.
  * This appears at the very beginning of an ELF binary. */
-struct ELF64_hdr {
-	unsigned char e_ident[EI_NIDENT];
-	uint16_t e_type;
-	uint16_t e_machine;
-	uint32_t e_version;
-	uint64_t e_entry;
-	uint64_t e_phoff;
-	uint64_t e_shoff;
-	uint32_t e_flags;
-	uint16_t e_ehsize;
-	uint16_t e_phentsize;
-	uint16_t e_phnum;
-	uint16_t e_shentsize;
-	uint16_t e_shnum;
-	uint16_t e_shstrndx;
+struct ELF64_hdr
+{
+    unsigned char e_ident[EI_NIDENT];
+    uint16_t e_type;
+    uint16_t e_machine;
+    uint32_t e_version;
+    uint64_t e_entry;
+    uint64_t e_phoff;
+    uint64_t e_shoff;
+    uint32_t e_flags;
+    uint16_t e_ehsize;
+    uint16_t e_phentsize;
+    uint16_t e_phnum;
+    uint16_t e_shentsize;
+    uint16_t e_shnum;
+    uint16_t e_shstrndx;
 };
 
-struct ELF64_PHDR {
-	uint32_t p_type;
-	uint32_t p_flags;
-	uint64_t p_offset;
-	uint64_t p_vaddr;
-	uint64_t p_paddr;
-	uint64_t p_filesz;
-	uint64_t p_memsz;
-	uint64_t p_align;
+struct ELF64_PHDR
+{
+    uint32_t p_type;
+    uint32_t p_flags;
+    uint64_t p_offset;
+    uint64_t p_vaddr;
+    uint64_t p_paddr;
+    uint64_t p_filesz;
+    uint64_t p_memsz;
+    uint64_t p_align;
 };
 
 /* Abbreviations */
 #define ELF ELF64_hdr
 #define Phdr ELF64_PHDR
 
-static bool setup_stack (struct intr_frame *if_);
-static bool validate_segment (const struct Phdr *, struct file *);
-static bool load_segment (struct file *file, off_t ofs, uint8_t *upage,
-		uint32_t read_bytes, uint32_t zero_bytes,
-		bool writable);
+static bool setup_stack(struct intr_frame *if_);
+static bool validate_segment(const struct Phdr *, struct file *);
+static bool load_segment(struct file *file, off_t ofs, uint8_t *upage,
+                         uint32_t read_bytes, uint32_t zero_bytes,
+                         bool writable);
 
 /* Loads an ELF executable from FILE_NAME into the current thread.
  * Stores the executable's entry point into *RIP
  * and its initial stack pointer into *RSP.
  * Returns true if successful, false otherwise. */
 static bool
-load (const char *file_name, struct intr_frame *if_) {
-	struct thread *t = thread_current ();
-	struct ELF ehdr;
-	struct file *file = NULL;
-	off_t file_ofs;
-	bool success = false;
-	int i;
+load(const char *file_name, struct intr_frame *if_)
+{
+    struct thread *t = thread_current();
+    struct ELF ehdr;
+    struct file *file = NULL;
+    off_t file_ofs;
+    bool success = false;
+    int i;
 
-	/* Allocate and activate page directory. */
-	t->pml4 = pml4_create ();
-	if (t->pml4 == NULL)
-		goto done;
-	process_activate (thread_current ());
+    /* Allocate and activate page directory. */
+    t->pml4 = pml4_create();
+    if (t->pml4 == NULL)
+        goto done;
+    process_activate(thread_current());
 
-	/* Open executable file. */
-	file = filesys_open (file_name);
-	if (file == NULL) {
-		printf ("load: %s: open failed\n", file_name);
-		goto done;
-	}
+    /* Open executable file. */
+    file = filesys_open(file_name);
+    if (file == NULL)
+    {
+        printf("load: %s: open failed\n", file_name);
+        goto done;
+    }
 
-	/* Read and verify executable header. */
-	if (file_read (file, &ehdr, sizeof ehdr) != sizeof ehdr
-			|| memcmp (ehdr.e_ident, "\177ELF\2\1\1", 7)
-			|| ehdr.e_type != 2
-			|| ehdr.e_machine != 0x3E // amd64
-			|| ehdr.e_version != 1
-			|| ehdr.e_phentsize != sizeof (struct Phdr)
-			|| ehdr.e_phnum > 1024) {
-		printf ("load: %s: error loading executable\n", file_name);
-		goto done;
-	}
+    /* Read and verify executable header. */
+    if (file_read(file, &ehdr, sizeof ehdr) != sizeof ehdr || memcmp(ehdr.e_ident, "\177ELF\2\1\1", 7) || ehdr.e_type != 2 || ehdr.e_machine != 0x3E // amd64
+        || ehdr.e_version != 1 || ehdr.e_phentsize != sizeof(struct Phdr) || ehdr.e_phnum > 1024)
+    {
+        printf("load: %s: error loading executable\n", file_name);
+        goto done;
+    }
 
-	/* Read program headers. */
-	file_ofs = ehdr.e_phoff;
-	for (i = 0; i < ehdr.e_phnum; i++) {
-		struct Phdr phdr;
+    /* Read program headers. */
+    file_ofs = ehdr.e_phoff;
+    for (i = 0; i < ehdr.e_phnum; i++)
+    {
+        struct Phdr phdr;
 
-		if (file_ofs < 0 || file_ofs > file_length (file))
-			goto done;
-		file_seek (file, file_ofs);
+        if (file_ofs < 0 || file_ofs > file_length(file))
+            goto done;
+        file_seek(file, file_ofs);
 
-		if (file_read (file, &phdr, sizeof phdr) != sizeof phdr)
-			goto done;
-		file_ofs += sizeof phdr;
-		switch (phdr.p_type) {
-			case PT_NULL:
-			case PT_NOTE:
-			case PT_PHDR:
-			case PT_STACK:
-			default:
-				/* Ignore this segment. */
-				break;
-			case PT_DYNAMIC:
-			case PT_INTERP:
-			case PT_SHLIB:
-				goto done;
-			case PT_LOAD:
-				if (validate_segment (&phdr, file)) {
-					bool writable = (phdr.p_flags & PF_W) != 0;
-					uint64_t file_page = phdr.p_offset & ~PGMASK;
-					uint64_t mem_page = phdr.p_vaddr & ~PGMASK;
-					uint64_t page_offset = phdr.p_vaddr & PGMASK;
-					uint32_t read_bytes, zero_bytes;
-					if (phdr.p_filesz > 0) {
-						/* Normal segment.
-						 * Read initial part from disk and zero the rest. */
-						read_bytes = page_offset + phdr.p_filesz;
-						zero_bytes = (ROUND_UP (page_offset + phdr.p_memsz, PGSIZE)
-								- read_bytes);
-					} else {
-						/* Entirely zero.
-						 * Don't read anything from disk. */
-						read_bytes = 0;
-						zero_bytes = ROUND_UP (page_offset + phdr.p_memsz, PGSIZE);
-					}
-					if (!load_segment (file, file_page, (void *) mem_page,
-								read_bytes, zero_bytes, writable))
-						goto done;
-				}
-				else
-					goto done;
-				break;
-		}
-	}
+        if (file_read(file, &phdr, sizeof phdr) != sizeof phdr)
+            goto done;
+        file_ofs += sizeof phdr;
+        switch (phdr.p_type)
+        {
+        case PT_NULL:
+        case PT_NOTE:
+        case PT_PHDR:
+        case PT_STACK:
+        default:
+            /* Ignore this segment. */
+            break;
+        case PT_DYNAMIC:
+        case PT_INTERP:
+        case PT_SHLIB:
+            goto done;
+        case PT_LOAD:
+            if (validate_segment(&phdr, file))
+            {
+                bool writable = (phdr.p_flags & PF_W) != 0;
+                uint64_t file_page = phdr.p_offset & ~PGMASK;
+                uint64_t mem_page = phdr.p_vaddr & ~PGMASK;
+                uint64_t page_offset = phdr.p_vaddr & PGMASK;
+                uint32_t read_bytes, zero_bytes;
+                if (phdr.p_filesz > 0)
+                {
+                    /* Normal segment.
+                     * Read initial part from disk and zero the rest. */
+                    read_bytes = page_offset + phdr.p_filesz;
+                    zero_bytes = (ROUND_UP(page_offset + phdr.p_memsz, PGSIZE) - read_bytes);
+                }
+                else
+                {
+                    /* Entirely zero.
+                     * Don't read anything from disk. */
+                    read_bytes = 0;
+                    zero_bytes = ROUND_UP(page_offset + phdr.p_memsz, PGSIZE);
+                }
+                if (!load_segment(file, file_page, (void *)mem_page,
+                                  read_bytes, zero_bytes, writable))
+                    goto done;
+            }
+            else
+                goto done;
+            break;
+        }
+    }
 
-	/* Set up stack. */
-	if (!setup_stack (if_))
-		goto done;
+    /* Set up stack. */
+    if (!setup_stack(if_))
+        goto done;
 
-	/* Start address. */
-	if_->rip = ehdr.e_entry;
+    /* Start address. */
+    if_->rip = ehdr.e_entry;
 
-	/* TODO: Your code goes here.
-	 * TODO: Implement argument passing (see project2/argument_passing.html). */
+    /* TODO: Your code goes here.
+     * TODO: Implement argument passing (see project2/argument_passing.html). */
 
-	success = true;
+    success = true;
 
 done:
-	/* We arrive here whether the load is successful or not. */
-	file_close (file);
-	return success;
+    /* We arrive here whether the load is successful or not. */
+    file_close(file);
+    return success;
 }
-
 
 /* Checks whether PHDR describes a valid, loadable segment in
  * FILE and returns true if so, false otherwise. */
 static bool
-validate_segment (const struct Phdr *phdr, struct file *file) {
-	/* p_offset and p_vaddr must have the same page offset. */
-	if ((phdr->p_offset & PGMASK) != (phdr->p_vaddr & PGMASK))
-		return false;
+validate_segment(const struct Phdr *phdr, struct file *file)
+{
+    /* p_offset and p_vaddr must have the same page offset. */
+    if ((phdr->p_offset & PGMASK) != (phdr->p_vaddr & PGMASK))
+        return false;
 
-	/* p_offset must point within FILE. */
-	if (phdr->p_offset > (uint64_t) file_length (file))
-		return false;
+    /* p_offset must point within FILE. */
+    if (phdr->p_offset > (uint64_t)file_length(file))
+        return false;
 
-	/* p_memsz must be at least as big as p_filesz. */
-	if (phdr->p_memsz < phdr->p_filesz)
-		return false;
+    /* p_memsz must be at least as big as p_filesz. */
+    if (phdr->p_memsz < phdr->p_filesz)
+        return false;
 
-	/* The segment must not be empty. */
-	if (phdr->p_memsz == 0)
-		return false;
+    /* The segment must not be empty. */
+    if (phdr->p_memsz == 0)
+        return false;
 
-	/* The virtual memory region must both start and end within the
-	   user address space range. */
-	if (!is_user_vaddr ((void *) phdr->p_vaddr))
-		return false;
-	if (!is_user_vaddr ((void *) (phdr->p_vaddr + phdr->p_memsz)))
-		return false;
+    /* The virtual memory region must both start and end within the
+       user address space range. */
+    if (!is_user_vaddr((void *)phdr->p_vaddr))
+        return false;
+    if (!is_user_vaddr((void *)(phdr->p_vaddr + phdr->p_memsz)))
+        return false;
 
-	/* The region cannot "wrap around" across the kernel virtual
-	   address space. */
-	if (phdr->p_vaddr + phdr->p_memsz < phdr->p_vaddr)
-		return false;
+    /* The region cannot "wrap around" across the kernel virtual
+       address space. */
+    if (phdr->p_vaddr + phdr->p_memsz < phdr->p_vaddr)
+        return false;
 
-	/* Disallow mapping page 0.
-	   Not only is it a bad idea to map page 0, but if we allowed
-	   it then user code that passed a null pointer to system calls
-	   could quite likely panic the kernel by way of null pointer
-	   assertions in memcpy(), etc. */
-	if (phdr->p_vaddr < PGSIZE)
-		return false;
+    /* Disallow mapping page 0.
+       Not only is it a bad idea to map page 0, but if we allowed
+       it then user code that passed a null pointer to system calls
+       could quite likely panic the kernel by way of null pointer
+       assertions in memcpy(), etc. */
+    if (phdr->p_vaddr < PGSIZE)
+        return false;
 
-	/* It's okay. */
-	return true;
+    /* It's okay. */
+    return true;
 }
 
 #ifndef VM
@@ -476,7 +503,7 @@ validate_segment (const struct Phdr *phdr, struct file *file) {
  * outside of #ifndef macro. */
 
 /* load() helpers. */
-static bool install_page (void *upage, void *kpage, bool writable);
+static bool install_page(void *upage, void *kpage, bool writable);
 
 /* Loads a segment starting at offset OFS in FILE at address
  * UPAGE.  In total, READ_BYTES + ZERO_BYTES bytes of virtual
@@ -493,62 +520,68 @@ static bool install_page (void *upage, void *kpage, bool writable);
  * Return true if successful, false if a memory allocation error
  * or disk read error occurs. */
 static bool
-load_segment (struct file *file, off_t ofs, uint8_t *upage,
-		uint32_t read_bytes, uint32_t zero_bytes, bool writable) {
-	ASSERT ((read_bytes + zero_bytes) % PGSIZE == 0);
-	ASSERT (pg_ofs (upage) == 0);
-	ASSERT (ofs % PGSIZE == 0);
+load_segment(struct file *file, off_t ofs, uint8_t *upage,
+             uint32_t read_bytes, uint32_t zero_bytes, bool writable)
+{
+    ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
+    ASSERT(pg_ofs(upage) == 0);
+    ASSERT(ofs % PGSIZE == 0);
 
-	file_seek (file, ofs);
-	while (read_bytes > 0 || zero_bytes > 0) {
-		/* Do calculate how to fill this page.
-		 * We will read PAGE_READ_BYTES bytes from FILE
-		 * and zero the final PAGE_ZERO_BYTES bytes. */
-		size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
-		size_t page_zero_bytes = PGSIZE - page_read_bytes;
+    file_seek(file, ofs);
+    while (read_bytes > 0 || zero_bytes > 0)
+    {
+        /* Do calculate how to fill this page.
+         * We will read PAGE_READ_BYTES bytes from FILE
+         * and zero the final PAGE_ZERO_BYTES bytes. */
+        size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
+        size_t page_zero_bytes = PGSIZE - page_read_bytes;
 
-		/* Get a page of memory. */
-		uint8_t *kpage = palloc_get_page (PAL_USER);
-		if (kpage == NULL)
-			return false;
+        /* Get a page of memory. */
+        uint8_t *kpage = palloc_get_page(PAL_USER);
+        if (kpage == NULL)
+            return false;
 
-		/* Load this page. */
-		if (file_read (file, kpage, page_read_bytes) != (int) page_read_bytes) {
-			palloc_free_page (kpage);
-			return false;
-		}
-		memset (kpage + page_read_bytes, 0, page_zero_bytes);
+        /* Load this page. */
+        if (file_read(file, kpage, page_read_bytes) != (int)page_read_bytes)
+        {
+            palloc_free_page(kpage);
+            return false;
+        }
+        memset(kpage + page_read_bytes, 0, page_zero_bytes);
 
-		/* Add the page to the process's address space. */
-		if (!install_page (upage, kpage, writable)) {
-			printf("fail\n");
-			palloc_free_page (kpage);
-			return false;
-		}
+        /* Add the page to the process's address space. */
+        if (!install_page(upage, kpage, writable))
+        {
+            printf("fail\n");
+            palloc_free_page(kpage);
+            return false;
+        }
 
-		/* Advance. */
-		read_bytes -= page_read_bytes;
-		zero_bytes -= page_zero_bytes;
-		upage += PGSIZE;
-	}
-	return true;
+        /* Advance. */
+        read_bytes -= page_read_bytes;
+        zero_bytes -= page_zero_bytes;
+        upage += PGSIZE;
+    }
+    return true;
 }
 
 /* Create a minimal stack by mapping a zeroed page at the USER_STACK */
 static bool
-setup_stack (struct intr_frame *if_) {
-	uint8_t *kpage;
-	bool success = false;
+setup_stack(struct intr_frame *if_)
+{
+    uint8_t *kpage;
+    bool success = false;
 
-	kpage = palloc_get_page (PAL_USER | PAL_ZERO);
-	if (kpage != NULL) {
-		success = install_page (((uint8_t *) USER_STACK) - PGSIZE, kpage, true);
-		if (success)
-			if_->rsp = USER_STACK;
-		else
-			palloc_free_page (kpage);
-	}
-	return success;
+    kpage = palloc_get_page(PAL_USER | PAL_ZERO);
+    if (kpage != NULL)
+    {
+        success = install_page(((uint8_t *)USER_STACK) - PGSIZE, kpage, true);
+        if (success)
+            if_->rsp = USER_STACK;
+        else
+            palloc_free_page(kpage);
+    }
+    return success;
 }
 
 /* Adds a mapping from user virtual address UPAGE to kernel
@@ -561,13 +594,13 @@ setup_stack (struct intr_frame *if_) {
  * Returns true on success, false if UPAGE is already mapped or
  * if memory allocation fails. */
 static bool
-install_page (void *upage, void *kpage, bool writable) {
-	struct thread *t = thread_current ();
+install_page(void *upage, void *kpage, bool writable)
+{
+    struct thread *t = thread_current();
 
-	/* Verify that there's not already a page at that virtual
-	 * address, then map our page there. */
-	return (pml4_get_page (t->pml4, upage) == NULL
-			&& pml4_set_page (t->pml4, upage, kpage, writable));
+    /* Verify that there's not already a page at that virtual
+     * address, then map our page there. */
+    return (pml4_get_page(t->pml4, upage) == NULL && pml4_set_page(t->pml4, upage, kpage, writable));
 }
 #else
 /* From here, codes will be used after project 3.
@@ -575,10 +608,11 @@ install_page (void *upage, void *kpage, bool writable) {
  * upper block. */
 
 static bool
-lazy_load_segment (struct page *page, void *aux) {
-	/* TODO: Load the segment from the file */
-	/* TODO: This called when the first page fault occurs on address VA. */
-	/* TODO: VA is available when calling this function. */
+lazy_load_segment(struct page *page, void *aux)
+{
+    /* TODO: Load the segment from the file */
+    /* TODO: This called when the first page fault occurs on address VA. */
+    /* TODO: VA is available when calling this function. */
 }
 
 /* Loads a segment starting at offset OFS in FILE at address
@@ -596,44 +630,47 @@ lazy_load_segment (struct page *page, void *aux) {
  * Return true if successful, false if a memory allocation error
  * or disk read error occurs. */
 static bool
-load_segment (struct file *file, off_t ofs, uint8_t *upage,
-		uint32_t read_bytes, uint32_t zero_bytes, bool writable) {
-	ASSERT ((read_bytes + zero_bytes) % PGSIZE == 0);
-	ASSERT (pg_ofs (upage) == 0);
-	ASSERT (ofs % PGSIZE == 0);
+load_segment(struct file *file, off_t ofs, uint8_t *upage,
+             uint32_t read_bytes, uint32_t zero_bytes, bool writable)
+{
+    ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
+    ASSERT(pg_ofs(upage) == 0);
+    ASSERT(ofs % PGSIZE == 0);
 
-	while (read_bytes > 0 || zero_bytes > 0) {
-		/* Do calculate how to fill this page.
-		 * We will read PAGE_READ_BYTES bytes from FILE
-		 * and zero the final PAGE_ZERO_BYTES bytes. */
-		size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
-		size_t page_zero_bytes = PGSIZE - page_read_bytes;
+    while (read_bytes > 0 || zero_bytes > 0)
+    {
+        /* Do calculate how to fill this page.
+         * We will read PAGE_READ_BYTES bytes from FILE
+         * and zero the final PAGE_ZERO_BYTES bytes. */
+        size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
+        size_t page_zero_bytes = PGSIZE - page_read_bytes;
 
-		/* TODO: Set up aux to pass information to the lazy_load_segment. */
-		void *aux = NULL;
-		if (!vm_alloc_page_with_initializer (VM_ANON, upage,
-					writable, lazy_load_segment, aux))
-			return false;
+        /* TODO: Set up aux to pass information to the lazy_load_segment. */
+        void *aux = NULL;
+        if (!vm_alloc_page_with_initializer(VM_ANON, upage,
+                                            writable, lazy_load_segment, aux))
+            return false;
 
-		/* Advance. */
-		read_bytes -= page_read_bytes;
-		zero_bytes -= page_zero_bytes;
-		upage += PGSIZE;
-	}
-	return true;
+        /* Advance. */
+        read_bytes -= page_read_bytes;
+        zero_bytes -= page_zero_bytes;
+        upage += PGSIZE;
+    }
+    return true;
 }
 
 /* Create a PAGE of stack at the USER_STACK. Return true on success. */
 static bool
-setup_stack (struct intr_frame *if_) {
-	bool success = false;
-	void *stack_bottom = (void *) (((uint8_t *) USER_STACK) - PGSIZE);
+setup_stack(struct intr_frame *if_)
+{
+    bool success = false;
+    void *stack_bottom = (void *)(((uint8_t *)USER_STACK) - PGSIZE);
 
-	/* TODO: Map the stack on stack_bottom and claim the page immediately.
-	 * TODO: If success, set the rsp accordingly.
-	 * TODO: You should mark the page is stack. */
-	/* TODO: Your code goes here */
+    /* TODO: Map the stack on stack_bottom and claim the page immediately.
+     * TODO: If success, set the rsp accordingly.
+     * TODO: You should mark the page is stack. */
+    /* TODO: Your code goes here */
 
-	return success;
+    return success;
 }
 #endif /* VM */

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -81,25 +81,33 @@ void syscall_handler(struct intr_frame *f UNUSED)
         break;
     case SYS_CREATE:
         f->R.rax = create(f->R.rdi, f->R.rsi);
+        break;
     case SYS_REMOVE:
         remove(f->R.rdi);
+        break;
     case SYS_OPEN:
         open(f->R.rdi);
+        break;
     case SYS_FILESIZE:
         filesize(f->R.rdi);
+        break;
     case SYS_READ:
         read(f->R.rdi, f->R.rsi, f->R.rdx);
+        break;
     case SYS_WRITE:
         f->R.rax = write(f->R.rdi, f->R.rsi, f->R.rdx);
         break;
     case SYS_SEEK:
         seek(f->R.rdi, f->R.rsi);
+        break;
     case SYS_TELL:
         tell(f->R.rdi);
+        break;
     case SYS_CLOSE:
         close(f->R.rdi);
+        break;
     }
-    thread_exit();
+    // thread_exit();
 }
 
 void check_address(struct intr_frame *intr_f)
@@ -124,7 +132,7 @@ void check_address(struct intr_frame *intr_f)
 void exit(int status)
 {
     printf("%s: exit(%d)\n", thread_current()->name, status);
-    thread_current()->exit_status = status;
+    // thread_current()->exit_status = status;
     thread_exit();
 }
 

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -7,9 +7,10 @@
 #include "userprog/gdt.h"
 #include "threads/flags.h"
 #include "intrinsic.h"
+#include "threads/init.h"
 
-void syscall_entry (void);
-void syscall_handler (struct intr_frame *);
+void syscall_entry(void);
+void syscall_handler(struct intr_frame *);
 
 /* System call.
  *
@@ -20,27 +21,99 @@ void syscall_handler (struct intr_frame *);
  * The syscall instruction works by reading the values from the the Model
  * Specific Register (MSR). For the details, see the manual. */
 
-#define MSR_STAR 0xc0000081         /* Segment selector msr */
-#define MSR_LSTAR 0xc0000082        /* Long mode SYSCALL target */
-#define MSR_SYSCALL_MASK 0xc0000084 /* Mask for the eflags */
+#define MSR_STAR 0xc0000081         /* Segment selector msr; 사용자 모드와 커널 모드 간 전환 시 사용할 세그먼트 셀렉터 설정 */
+#define MSR_LSTAR 0xc0000082        /* Long mode SYSCALL target; 명령어 실행 시 호출될 함수의 주소 설정, syscall_entry의 주소 설정 */
+#define MSR_SYSCALL_MASK 0xc0000084 /* Mask for the eflags; system call 동안 마스킹될 EFLAGS 레지스터의 비트 설정 */
 
-void
-syscall_init (void) {
-	write_msr(MSR_STAR, ((uint64_t)SEL_UCSEG - 0x10) << 48  |
-			((uint64_t)SEL_KCSEG) << 32);
-	write_msr(MSR_LSTAR, (uint64_t) syscall_entry);
+void syscall_init(void)
+{
+    write_msr(MSR_STAR, ((uint64_t)SEL_UCSEG - 0x10) << 48 |
+                            ((uint64_t)SEL_KCSEG) << 32);
+    write_msr(MSR_LSTAR, (uint64_t)syscall_entry);
 
-	/* The interrupt service rountine should not serve any interrupts
-	 * until the syscall_entry swaps the userland stack to the kernel
-	 * mode stack. Therefore, we masked the FLAG_FL. */
-	write_msr(MSR_SYSCALL_MASK,
-			FLAG_IF | FLAG_TF | FLAG_DF | FLAG_IOPL | FLAG_AC | FLAG_NT);
+    /* The interrupt service rountine should not serve any interrupts
+     * until the syscall_entry swaps the userland stack to the kernel
+     * mode stack. Therefore, we masked the FLAG_FL. */
+    write_msr(MSR_SYSCALL_MASK,
+              FLAG_IF | FLAG_TF | FLAG_DF | FLAG_IOPL | FLAG_AC | FLAG_NT);
 }
 
 /* The main system call interface */
-void
-syscall_handler (struct intr_frame *f UNUSED) {
-	// TODO: Your implementation goes here.
-	printf ("system call!\n");
-	thread_exit ();
+void syscall_handler(struct intr_frame *f UNUSED)
+{
+    // TODO: Your implementation goes here.
+    printf("system call!\n");
+    // printf("system call number: %d \n", f->R.rax);
+    check_address(f);
+
+    switch (f->R.rax)
+    {
+    case SYS_HALT:
+        halt();
+        break;
+    case SYS_EXIT:
+        exit(f->R.rdi);
+        break;
+    case SYS_EXEC:
+        break;
+    case SYS_WAIT:
+        break;
+    case SYS_CREATE:
+        break;
+    case SYS_REMOVE:
+        break;
+    case SYS_OPEN:
+        break;
+    case SYS_FILESIZE:
+        break;
+    case SYS_READ:
+        break;
+    case SYS_WRITE:
+        break;
+    case SYS_SEEK:
+        break;
+    case SYS_TELL:
+        break;
+    case SYS_CLOSE:
+        break;
+    case SYS_MMAP:
+        break;
+    }
+}
+
+void check_address(struct intr_frame *intr_f)
+{
+    // printf("checking if address is invalid.. \n");
+    // printf("your requested address is: %x \n", intr_f->rsp);
+
+    if (is_kernel_vaddr(intr_f->rsp))
+    {
+        // printf("requested address is kernel's address \n");
+        exit(-1);
+    }
+    if (intr_f->rsp == NULL)
+    {
+        // printf("requested address is NULL \n");
+        exit(-1);
+    }
+    if (pml4_get_page(thread_current()->pml4, intr_f->rsp) == NULL)
+    {
+        // printf("requested address is not mapped \n");
+        exit(-1);
+    }
+    else
+    {
+        // printf("syscall request is valid, moving on to syscall handler... \n");
+    }
+}
+
+void exit(int status)
+{
+    printf("%s: exit(%d)\n", thread_current()->name, status);
+    thread_exit();
+}
+
+void halt(void)
+{
+    power_off();
 }


### PR DESCRIPTION
## Argument passing, system call 구현

- 테스트케이스 통과 목록

pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
FAIL tests/userprog/close-normal
FAIL tests/userprog/close-twice
FAIL tests/userprog/close-bad-fd
FAIL tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
FAIL tests/userprog/read-boundary
FAIL tests/userprog/read-zero
FAIL tests/userprog/read-stdout
FAIL tests/userprog/read-bad-fd
FAIL tests/userprog/write-normal
FAIL tests/userprog/write-bad-ptr
FAIL tests/userprog/write-boundary
FAIL tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
FAIL tests/userprog/fork-once
FAIL tests/userprog/fork-multiple
FAIL tests/userprog/fork-recursive
FAIL tests/userprog/fork-read
FAIL tests/userprog/fork-close
FAIL tests/userprog/fork-boundary
FAIL tests/userprog/exec-once
FAIL tests/userprog/exec-arg
FAIL tests/userprog/exec-boundary
FAIL tests/userprog/exec-missing
FAIL tests/userprog/exec-bad-ptr
FAIL tests/userprog/exec-read
FAIL tests/userprog/wait-simple
FAIL tests/userprog/wait-twice
FAIL tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
FAIL tests/userprog/multi-recurse
FAIL tests/userprog/multi-child-fd
FAIL tests/userprog/rox-simple
FAIL tests/userprog/rox-child
FAIL tests/userprog/rox-multichild
FAIL tests/userprog/bad-read
FAIL tests/userprog/bad-write
FAIL tests/userprog/bad-read2
FAIL tests/userprog/bad-write2
FAIL tests/userprog/bad-jump
FAIL tests/userprog/bad-jump2
FAIL tests/filesys/base/lg-create
FAIL tests/filesys/base/lg-full
FAIL tests/filesys/base/lg-random
FAIL tests/filesys/base/lg-seq-block
FAIL tests/filesys/base/lg-seq-random
FAIL tests/filesys/base/sm-create
FAIL tests/filesys/base/sm-full
FAIL tests/filesys/base/sm-random
FAIL tests/filesys/base/sm-seq-block
FAIL tests/filesys/base/sm-seq-random
FAIL tests/filesys/base/syn-read
FAIL tests/filesys/base/syn-remove
FAIL tests/filesys/base/syn-write
FAIL tests/userprog/no-vm/multi-oom
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
